### PR TITLE
Serve prototype from repository root

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,846 @@
+:root {
+  --bg-color: #0f172a;
+  --panel-color: #111c34;
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --text-color: #f8fafc;
+  --muted: #94a3b8;
+  --danger: #f87171;
+  --warning: #facc15;
+  --success: #4ade80;
+  --border-radius: 16px;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+  --transition: 0.3s ease;
+  --panel-padding: clamp(16px, 2vw, 32px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(96, 165, 250, 0.12), transparent 55%),
+    var(--bg-color);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+.visually-hidden {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+}
+
+.app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 48px) clamp(12px, 4vw, 48px) 120px;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: clamp(20px, 4vw, 48px);
+}
+
+header h1 {
+  font-size: clamp(28px, 3vw, 44px);
+  margin: 0;
+  font-weight: 700;
+}
+
+header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 720px;
+  font-size: clamp(16px, 2vw, 18px);
+}
+
+.summary-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+main {
+  display: grid;
+  gap: clamp(16px, 3vw, 32px);
+}
+
+.screen {
+  display: none;
+  background: linear-gradient(145deg, rgba(17, 28, 52, 0.88), rgba(12, 19, 35, 0.92));
+  border-radius: var(--border-radius);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow);
+  padding: var(--panel-padding);
+}
+
+.screen.active {
+  display: block;
+}
+
+.screen header {
+  margin-bottom: 16px;
+}
+
+.section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: clamp(22px, 2.5vw, 32px);
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 16px;
+  color: var(--muted);
+}
+
+.drop-zone {
+  border: 1.5px dashed rgba(56, 189, 248, 0.5);
+  border-radius: var(--border-radius);
+  padding: clamp(32px, 4vw, 64px);
+  text-align: center;
+  background: rgba(8, 47, 73, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
+.drop-zone.dragover {
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.drop-zone button,
+.button-primary,
+.button-secondary,
+.button-ghost {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 12px;
+  padding: 12px 20px;
+  border: none;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.button-primary {
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.button-primary:hover,
+.button-primary:focus {
+  background: var(--accent-strong);
+  outline: none;
+}
+
+.button-secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-color);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.button-primary:disabled,
+.button-secondary:disabled,
+.button-ghost:disabled,
+.drop-zone button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.button-ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+}
+
+.button-ghost:hover,
+.button-ghost:focus {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.input-file {
+  position: relative;
+  overflow: hidden;
+}
+
+.input-file input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.upload-summary {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 24px;
+}
+
+.summary-card {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.summary-card strong {
+  font-size: 28px;
+}
+
+.summary-card span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.tablist {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.tablist button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  color: var(--muted);
+}
+
+.tablist button[aria-selected="true"] {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text-color);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.file-list {
+  margin-top: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.file-group {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.file-group summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 16px 18px;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-color);
+  background: rgba(8, 47, 73, 0.35);
+}
+
+.file-group summary::-webkit-details-marker {
+  display: none;
+}
+
+.file-group[open] summary {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.file-group .file-row {
+  background: transparent;
+}
+
+.period-label {
+  background: rgba(56, 189, 248, 0.1) !important;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.period-label span {
+  font-weight: 600;
+  grid-column: 1 / -1;
+}
+
+.file-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 2fr) repeat(3, minmax(120px, 1fr)) minmax(120px, 1fr);
+  gap: 12px;
+  padding: 14px 18px;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.4);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.file-row:nth-child(odd) {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.file-row span {
+  font-size: 14px;
+}
+
+.file-status {
+  justify-self: end;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.file-status[data-status="recognized"] {
+  background: rgba(74, 222, 128, 0.8);
+}
+
+.file-status[data-status="mapping"] {
+  background: rgba(250, 204, 21, 0.8);
+}
+
+.file-status[data-status="duplicate"] {
+  background: rgba(148, 163, 184, 0.8);
+}
+
+.file-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.progress-container {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 12px;
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), #60a5fa);
+  transition: width 0.2s ease;
+}
+
+.progress-steps {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.progress-step {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 13px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.progress-step.active {
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+}
+
+.triad-nav {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.triad-nav button {
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--muted);
+}
+
+.triad-nav button[aria-pressed="true"] {
+  color: var(--text-color);
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.metric-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.metric-card .metric-value {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.metric-note {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 15px;
+}
+
+.toggle input[type="checkbox"] {
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  appearance: none;
+  background: rgba(148, 163, 184, 0.3);
+  position: relative;
+  transition: background var(--transition);
+}
+
+.toggle input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform var(--transition);
+}
+
+.toggle input[type="checkbox"]:checked {
+  background: var(--accent);
+}
+
+.toggle input[type="checkbox"]:checked::after {
+  transform: translateX(18px);
+}
+
+.elimination-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.elimination-item {
+  border-radius: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  padding: 14px;
+  background: rgba(8, 47, 73, 0.3);
+}
+
+.info-hints {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.info-hints p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.detectors-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.detector-panel {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.detector-panel h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.range-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.range-control input[type="range"] {
+  flex: 1;
+}
+
+.receivable-row,
+.inventory-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1.5fr) repeat(2, minmax(120px, 1fr)) minmax(120px, 1fr);
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  font-size: 14px;
+}
+
+.highlight-red {
+  color: var(--danger);
+}
+
+.highlight-yellow {
+  color: var(--warning);
+}
+
+.highlight-green {
+  color: var(--success);
+}
+
+.inventory-flags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.inventory-flags span {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.inventory-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.inventory-filters label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 13px;
+}
+
+.inventory-filters input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.liquidation-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.liquidation-card {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.liquidation-card h3 {
+  margin: 0;
+}
+
+.liquidation-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.traffic-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.traffic-controls select {
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-color);
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 8px 12px;
+}
+
+.traffic-controls button.active {
+  background: rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+}
+
+.traffic-list {
+  margin-top: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.traffic-card {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-pill[data-status="green"] {
+  background: rgba(74, 222, 128, 0.18);
+  color: var(--success);
+}
+
+.status-pill[data-status="yellow"] {
+  background: rgba(250, 204, 21, 0.18);
+  color: var(--warning);
+}
+
+.status-pill[data-status="red"] {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--danger);
+}
+
+.final-screen {
+  text-align: center;
+  display: grid;
+  gap: 16px;
+}
+
+.final-screen ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.final-screen li {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.disclaimer {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.cta-floating {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: var(--accent);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 16px 24px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+  border: none;
+  transition: transform var(--transition), background var(--transition);
+  z-index: 1000;
+}
+
+.cta-floating:hover,
+.cta-floating:focus {
+  background: var(--accent-strong);
+  transform: translateY(-4px);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 900;
+}
+
+.modal {
+  background: rgba(10, 20, 36, 0.95);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 24px;
+  width: min(90vw, 420px);
+  display: grid;
+  gap: 16px;
+}
+
+.modal h3 {
+  margin: 0;
+}
+
+.modal p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 1024px) {
+  .file-row {
+    grid-template-columns: minmax(160px, 2fr) repeat(2, minmax(120px, 1fr)) minmax(100px, 1fr);
+  }
+
+  .receivable-row,
+  .inventory-row {
+    grid-template-columns: minmax(140px, 1.2fr) minmax(100px, 1fr) minmax(100px, 1fr);
+  }
+
+  .receivable-row span:last-child,
+  .inventory-row span:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding-bottom: 140px;
+  }
+
+  header {
+    text-align: left;
+  }
+
+  .file-row {
+    grid-template-columns: minmax(140px, 2fr) minmax(100px, 1fr);
+    grid-template-areas:
+      "name status"
+      "meta meta";
+    gap: 8px;
+  }
+
+  .file-row span:nth-child(1) {
+    grid-area: name;
+  }
+
+  .file-row span:nth-child(2),
+  .file-row span:nth-child(3),
+  .file-row span:nth-child(4) {
+    grid-area: meta;
+    font-size: 13px;
+    color: var(--muted);
+  }
+
+  .file-row .file-status {
+    grid-area: status;
+    justify-self: end;
+  }
+
+  .file-actions {
+    grid-column: 1 / -1;
+  }
+
+  .receivable-row,
+  .inventory-row {
+    grid-template-columns: minmax(140px, 1fr);
+  }
+
+  .cta-floating {
+    left: 16px;
+    right: 16px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .drop-zone {
+    padding: 24px;
+  }
+
+  .summary-card {
+    min-height: auto;
+  }
+
+  .triad-nav {
+    flex-direction: column;
+  }
+
+  .triad-nav button {
+    width: 100%;
+  }
+}

--- a/assets/data/mockData.json
+++ b/assets/data/mockData.json
@@ -1,0 +1,1132 @@
+{
+  "uploadScenarios": [
+    {
+      "id": "singleCompany",
+      "label": "Одна компания, много файлов",
+      "summary": {
+        "companies": 1,
+        "files": 12,
+        "periods": 4,
+        "formats": ["xlsx", "csv"],
+        "description": "Разнобой периодов и форматов для одной компании"
+      },
+      "recognition": {
+        "recognized": 7,
+        "needsMapping": 3,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "ОСВ_январь.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "ОФР_Q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "ОФР_Q1_v2.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "баланс_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "запасы_февраль.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Сопоставить с классификатором запасов"
+        },
+        {
+          "name": "дебиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "кредиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHint": "Требуется указать тип отчёта"
+        },
+        {
+          "name": "движение_денег.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "инвентаризация_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Уточнить период учёта"
+        },
+        {
+          "name": "реестр_контрагентов.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "юрисобытия_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "архив_выручка_2022.xlsx",
+          "company": "Компания А",
+          "period": "2022",
+          "periodLabel": "2022",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распознала компанию по шапке файлов.",
+          "suggestion": "Компания А • ИНН 7701234567"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По заголовку файла предполагаем ОФР за период.",
+          "suggestion": "ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Подсказка из имени файла",
+          "suggestion": "I квартал 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "ОФР_Q1",
+          "files": ["ОФР_Q1.csv", "ОФР_Q1_v2.csv"],
+          "messages": {
+            "keepNew": "Новая версия сохранена. Предыдущая отправлена в архив.",
+            "keepOld": "Оставили исходный файл. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена. Строк объединено: 184."
+          }
+        }
+      ]
+    },
+    {
+      "id": "groupUpload",
+      "label": "Группа компаний, много файлов",
+      "summary": {
+        "companies": 3,
+        "files": 31,
+        "periods": 6,
+        "formats": ["xlsx", "csv", "txt"],
+        "description": "Каждая компания прислала свою пачку"
+      },
+      "recognition": {
+        "recognized": 24,
+        "needsMapping": 5,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "Компания_A/OSV_jan.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/OSV_feb.xlsx",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/OSV_mar.xlsx",
+          "company": "Компания А",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/bal_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/pnl_q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/debt_q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_A/inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Нужно сопоставить коды ТМЦ"
+        },
+        {
+          "name": "Компания_A/legal_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/OSV_q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/pnl_q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/balance_31-03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/loans.txt",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "mappingHint": "Указать структуру колонок"
+        },
+        {
+          "name": "Компания_B/inventory_mar.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "склад"
+        },
+        {
+          "name": "Компания_B/debt_feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_B/legal_2024.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_C/osv_q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/pnl_q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/balance_31-03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/inventory_mar.csv",
+          "company": "Компания C",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "склад"
+        },
+        {
+          "name": "Компания_C/debt_mar.xlsx",
+          "company": "Компания C",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHint": "Проверить валюту"
+        },
+        {
+          "name": "Компания_C/contracts.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "Компания_C/legal_2024.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/pnl_feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_B_ОФР_Q1",
+          "origin": "альтернативная версия"
+        },
+        {
+          "name": "Компания_B/pnl_feb_v2.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_B_ОФР_Q1",
+          "origin": "альтернативная версия"
+        },
+        {
+          "name": "Компания_A/cashflow_q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_A/projects.txt",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "mappingHint": "Указать тип выгрузки"
+        },
+        {
+          "name": "Компания_B/receivables_jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_C/receivables_jan.xlsx",
+          "company": "Компания C",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_B/suppliers.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_A/suppliers.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_C/suppliers.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_A/legal_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/legal_2023.csv",
+          "company": "Компания B",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_C/legal_2023.csv",
+          "company": "Компания C",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Из названия папки система определила группу.",
+          "suggestion": "Группа компаний АБВ"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По столбцам определён формат ОСВ.",
+          "suggestion": "ОСВ (на дату)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Предложенный период совпадает с заголовком.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Компания_B_ОФР_Q1",
+          "files": ["Компания_B/pnl_feb.xlsx", "Компания_B/pnl_feb_v2.xlsx"],
+          "messages": {
+            "keepNew": "Новая версия отчёта по Компании B сохранена.",
+            "keepOld": "Сохранили исходный отчёт. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена для Компании B. Строк объединено: 236."
+          }
+        }
+      ]
+    },
+    {
+      "id": "zipArchive",
+      "label": "ZIP-архив группы",
+      "summary": {
+        "companies": 3,
+        "files": 28,
+        "periods": 5,
+        "formats": ["zip"],
+        "description": "Архив с вложенными папками компаний"
+      },
+      "recognition": {
+        "recognized": 21,
+        "needsMapping": 4,
+        "duplicates": 3
+      },
+      "files": [
+        {
+          "name": "group_upload.zip/Company_A/OSV_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/PnL_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Balance_31_03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Нужно подтвердить единицы измерения"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Receivables.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/OSV_2024_Q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Mar.xlsx",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Balance_31_03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Inventory_march.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Receivables.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/OSV_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/PnL_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Balance_31_03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Inventory_feb.csv",
+          "company": "Компания C",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Уточнить склад"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Receivables.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/security/events.csv",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/security/partners.xlsx",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/Company_A/cashflow.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/cashflow.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/cashflow.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/readme.txt",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/projects.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/Company_B/projects.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/Company_C/projects.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/security/archive_2023.zip",
+          "company": "Группа",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "zip",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/loans.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Архив содержит подпапки по компаниям.",
+          "suggestion": "Компания А • Компания B • Компания C"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По структуре данных распознаны ОСВ и ОФР.",
+          "suggestion": "Баланс (на дату) и ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Выделен диапазон по именам файлов.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Company_B_PnL",
+          "files": [
+            "group_upload.zip/Company_B/PnL_Jan.xlsx",
+            "group_upload.zip/Company_B/PnL_Feb.xlsx",
+            "group_upload.zip/Company_B/PnL_Mar.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Сохранён последний файл за март, предыдущие помечены как исторические.",
+            "keepOld": "Сохранили январскую версию, остальные спрятаны в архив.",
+            "merge": "Объединение трёх файлов завершено. Строк объединено: 312."
+          }
+        }
+      ]
+    }
+  ],
+  "consolidation": {
+    "baseSummary": {
+      "companies": 5,
+      "files": 42,
+      "period": "I квартал 2024",
+      "eliminatedPairs": 8
+    },
+    "totals": {
+      "before": {
+        "revenue": 154000000,
+        "cogs": 112500000,
+        "grossMargin": 41500000,
+        "interestPayable": 2200000,
+        "interestReceivable": 2200000,
+        "intraRevenue": 11000000,
+        "intraCogs": 11000000,
+        "note": "До элиминации внутригрупповые обороты и проценты увеличивают обороты"
+      },
+      "after": {
+        "revenue": 143000000,
+        "cogs": 101500000,
+        "grossMargin": 41500000,
+        "interestPayable": 0,
+        "interestReceivable": 0,
+        "note": "Элиминации убрали внутригрупповую выручку и проценты"
+      }
+    },
+    "eliminationEntries": [
+      {
+        "pair": "Компания А → Компания B",
+        "description": "Поставка сырья",
+        "amount": 11000000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания B → Компания D",
+        "description": "Проценты по займу",
+        "amount": 2200000,
+        "metric": "Проценты к получению/уплате"
+      },
+      {
+        "pair": "Компания C ↔ Компания E",
+        "description": "Внутригрупповые услуги",
+        "amount": 3600000,
+        "metric": "Выручка/Прочие расходы"
+      },
+      {
+        "pair": "Компания А ↔ Компания C",
+        "description": "Расхождение по остаткам",
+        "amount": 1000000,
+        "metric": "Консервативная корректировка по большей сумме"
+      }
+    ],
+    "infoNotes": [
+      "Баланс — на дату. ОФР — за период. Аналогия: камера мгновенной и средней скорости.",
+      "Элиминации — снятие внутригрупповых оборотов для честного результата."
+    ],
+    "ruleHints": [
+      "Элиминация процентов к уплате и к получению по внутригрупповым займам.",
+      "Консервативная корректировка: при расхождениях берём большую сумму.",
+      "Правило баланса: нет двойного учёта между дочерними компаниями."
+    ]
+  },
+  "detectors": {
+    "receivables": [
+      {
+        "counterparty": "Торговый дом \"Север\"",
+        "company": "Компания А",
+        "days": 210,
+        "amount": 4200000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Метеор\"",
+        "company": "Компания B",
+        "days": 275,
+        "amount": 3200000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ЗАО \"Партнёр\"",
+        "company": "Компания C",
+        "days": 165,
+        "amount": 1800000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ИП Сафронов",
+        "company": "Компания D",
+        "days": 95,
+        "amount": 950000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "АО \"Логистика\"",
+        "company": "Компания Е",
+        "days": 188,
+        "amount": 2400000,
+        "source": "дебиторка_Q1.xlsx"
+      }
+    ],
+    "inventory": [
+      {
+        "item": "Партия кабеля КБ-14",
+        "company": "Компания B",
+        "issues": ["долго лежит"],
+        "amount": 1250000,
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "item": "Компоненты серии X17",
+        "company": "Компания А",
+        "issues": ["истёк срок"],
+        "amount": 840000,
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "item": "Готовая продукция L2",
+        "company": "Компания C",
+        "issues": ["брак", "долго лежит"],
+        "amount": 1560000,
+        "source": "inventory_mar.csv"
+      },
+      {
+        "item": "Материалы проекта R",
+        "company": "Компания D",
+        "issues": ["долго лежит"],
+        "amount": 610000,
+        "source": "inventory_mar.csv"
+      }
+    ],
+    "legend": {
+      "receivables": "Дебиторка",
+      "inventory": "Запасы"
+    }
+  },
+  "liquidation": {
+    "before": {
+      "equity": 72000000,
+      "cash": 18500000,
+      "assets": [
+        {
+          "label": "Дебиторская задолженность",
+          "amount": 32500000
+        },
+        {
+          "label": "Запасы",
+          "amount": 26800000
+        },
+        {
+          "label": "Основные средства",
+          "amount": 54000000
+        }
+      ]
+    },
+    "adjustments": [
+      {
+        "label": "Списание дебитора ООО \"Метеор\"",
+        "impact": -3200000,
+        "reason": ">270 дней без оплаты",
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "label": "Списание партии КБ-14",
+        "impact": -1250000,
+        "reason": "неликвид > 9 месяцев",
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "label": "Дисконт готовой продукции L2",
+        "impact": -780000,
+        "reason": "брак, продажа с уценкой",
+        "source": "inventory_mar.csv"
+      }
+    ],
+    "after": {
+      "equity": 52000000,
+      "cash": 41000000,
+      "ownerStatement": "Оценка: при продаже бизнеса собственник получит около 41 млн руб. живыми деньгами."
+    }
+  },
+  "trafficLight": {
+    "statusLabels": {
+      "all": "Все",
+      "green": "Зелёные",
+      "yellow": "Жёлтые",
+      "red": "Красные"
+    },
+    "items": [
+      {
+        "name": "ООО \"Форвард\"",
+        "company": "Компания А",
+        "status": "green",
+        "financial": "Платёж дисциплинирован, оборачиваемость 35 дней.",
+        "legal": "Нет активных судебных дел.",
+        "note": "Допустимый лимит 12 млн руб."
+      },
+      {
+        "name": "АО \"Логистика\"",
+        "company": "Компания Е",
+        "status": "yellow",
+        "financial": "Рост просрочки до 45 дней.",
+        "legal": "Имеется исполнительное производство на небольшую сумму.",
+        "note": "Рекомендация: запросить обновлённые документы."
+      },
+      {
+        "name": "ООО \"Метеор\"",
+        "company": "Компания B",
+        "status": "red",
+        "financial": "Просрочка 275 дней, выручка снижается.",
+        "legal": "Сообщение о намерении банкротства.",
+        "note": "Поставки остановлены, требуется контроль."
+      },
+      {
+        "name": "ЗАО \"Партнёр\"",
+        "company": "Компания C",
+        "status": "yellow",
+        "financial": "Просрочка 165 дней, частичные платежи.",
+        "legal": "Претензионная работа без суда.",
+        "note": "Дополнительное согласование скидок."
+      },
+      {
+        "name": "ИП Сафронов",
+        "company": "Компания D",
+        "status": "green",
+        "financial": "Оплата вовремя, обороты стабильны.",
+        "legal": "Нет событий.",
+        "note": "Можно расширить лимит до 5 млн руб."
+      }
+    ]
+  },
+  "finalSummary": {
+    "headline": "Минуты вместо дней. Минимум ручного труда. Триада готова.",
+    "points": [
+      "Файлы собраны, нормализованы и сведены в одну базу.",
+      "Проблемные зоны подсвечены автоматически.",
+      "Команда видит, где действовать первой."],
+    "disclaimer": "Демонстрационный прототип. Данные и расчёты упрощены."
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,1098 @@
+const state = {
+  config: null,
+  data: null,
+  currentScenario: null,
+  mappingComplete: false,
+  duplicateDecisions: new Map(),
+  flaggedReceivables: new Set(),
+  threshold: null,
+  inventoryFilters: new Set(),
+  liquidationCleaned: false,
+  trafficFilter: 'all',
+  trafficCompany: 'all',
+  progressStart: 0,
+  progressDuration: 0,
+  progressFrame: null,
+  lastUploadCount: 0
+};
+
+const elements = {};
+
+const numberFormatter = new Intl.NumberFormat('ru-RU');
+
+document.addEventListener('DOMContentLoaded', init);
+
+async function init() {
+  cacheElements();
+  setDemoScenarioAvailability(false);
+  const resources = await loadResources();
+  if (!resources) {
+    displayResourceLoadError();
+    return;
+  }
+
+  state.config = resources.config;
+  state.data = resources.data;
+
+  setupEventHandlers();
+  initializeProgressSteps();
+  initializeInventoryFilters();
+  initializeTrafficFilters();
+  initializeTrafficCompanies();
+  renderFinalScreen();
+  updateCTA();
+  renderTrafficList();
+
+  setDemoScenarioAvailability(true);
+}
+
+function cacheElements() {
+  elements.dropZone = document.getElementById('dropZone');
+  elements.fileInput = document.getElementById('fileInput');
+  elements.demoScenario = document.getElementById('demoScenario');
+  elements.summaryFiles = document.getElementById('summary-files');
+  elements.summaryCompanies = document.getElementById('summary-companies');
+  elements.summaryPeriods = document.getElementById('summary-periods');
+  elements.summaryFormats = document.getElementById('summary-formats');
+  elements.summaryDescription = document.getElementById('summary-description');
+  elements.recognitionLegend = document.getElementById('recognition-legend');
+  elements.badgeFiles = document.getElementById('badge-files');
+  elements.badgeCompanies = document.getElementById('badge-companies');
+  elements.badgePeriods = document.getElementById('badge-periods');
+  elements.badgeFormats = document.getElementById('badge-formats');
+  elements.companyFileList = document.getElementById('companyFileList');
+  elements.periodFileList = document.getElementById('periodFileList');
+  elements.tabCompanies = document.getElementById('tab-companies');
+  elements.tabPeriods = document.getElementById('tab-periods');
+  elements.panelCompanies = document.getElementById('panel-companies');
+  elements.panelPeriods = document.getElementById('panel-periods');
+  elements.attentionList = document.getElementById('attentionList');
+  elements.duplicateList = document.getElementById('duplicateList');
+  elements.startMapping = document.getElementById('startMapping');
+  elements.startConsolidation = document.getElementById('startConsolidation');
+  elements.uploadScreen = document.getElementById('upload-screen');
+  elements.progressScreen = document.getElementById('progress-screen');
+  elements.triadScreen = document.getElementById('triad-screen');
+  elements.progressIndicator = document.getElementById('progressIndicator');
+  elements.progressValue = document.getElementById('progressValue');
+  elements.progressSteps = document.getElementById('progressSteps');
+  elements.progressStatus = document.getElementById('progressStatus');
+  elements.triadNavButtons = document.querySelectorAll('.triad-nav-btn');
+  elements.consolidationMetrics = document.getElementById('consolidationMetrics');
+  elements.toggleElimination = document.getElementById('toggleElimination');
+  elements.showEliminations = document.getElementById('showEliminations');
+  elements.eliminationDetails = document.getElementById('eliminationDetails');
+  elements.consolidationHints = document.getElementById('consolidationHints');
+  elements.consolidationRules = document.getElementById('consolidationRules');
+  elements.thresholdRange = document.getElementById('thresholdRange');
+  elements.thresholdValue = document.getElementById('thresholdValue');
+  elements.receivablesList = document.getElementById('receivablesList');
+  elements.sendToTraffic = document.getElementById('sendToTraffic');
+  elements.trafficMessage = document.getElementById('trafficMessage');
+  elements.inventoryFilters = document.getElementById('inventoryFilters');
+  elements.inventoryList = document.getElementById('inventoryList');
+  elements.cleanBalance = document.getElementById('cleanBalance');
+  elements.liquidationBeforeSummary = document.getElementById('liquidationBeforeSummary');
+  elements.liquidationAssets = document.getElementById('liquidationAssets');
+  elements.liquidationAdjustments = document.getElementById('liquidationAdjustments');
+  elements.liquidationAfterSummary = document.getElementById('liquidationAfterSummary');
+  elements.ownerStatement = document.getElementById('ownerStatement');
+  elements.trafficFilters = document.getElementById('trafficFilters');
+  elements.trafficCompany = document.getElementById('trafficCompany');
+  elements.trafficList = document.getElementById('trafficList');
+  elements.finalHeadline = document.getElementById('finalHeadline');
+  elements.finalPoints = document.getElementById('finalPoints');
+  elements.finalDisclaimer = document.getElementById('finalDisclaimer');
+  elements.ctaButton = document.getElementById('ctaButton');
+  elements.mappingTemplate = document.getElementById('mappingStepTemplate');
+}
+
+function setDemoScenarioAvailability(enabled) {
+  if (!elements.demoScenario) {
+    return;
+  }
+  elements.demoScenario.disabled = !enabled;
+  if (enabled) {
+    elements.demoScenario.removeAttribute('aria-disabled');
+  } else {
+    elements.demoScenario.setAttribute('aria-disabled', 'true');
+  }
+}
+
+function setupEventHandlers() {
+  elements.dropZone.addEventListener('dragover', onDragOver);
+  elements.dropZone.addEventListener('dragleave', onDragLeave);
+  elements.dropZone.addEventListener('drop', onDropFiles);
+  elements.dropZone.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      elements.fileInput.click();
+    }
+  });
+
+  elements.fileInput.addEventListener('change', (event) => {
+    handleFiles(event.target.files);
+  });
+
+  elements.demoScenario.addEventListener('click', () => {
+    if (!state.data?.uploadScenarios?.length) {
+      return;
+    }
+    const scenario = state.data.uploadScenarios[1] || state.data.uploadScenarios[0];
+    loadScenario(scenario, scenario.summary.files);
+  });
+
+  elements.tabCompanies.addEventListener('click', () => setActiveTab('companies'));
+  elements.tabPeriods.addEventListener('click', () => setActiveTab('periods'));
+  [elements.tabCompanies, elements.tabPeriods].forEach((tab) => {
+    tab.addEventListener('keydown', onTabKeydown);
+  });
+
+  elements.startMapping.addEventListener('click', openMappingWizard);
+  elements.startConsolidation.addEventListener('click', startConsolidation);
+
+  elements.triadNavButtons.forEach((button) => {
+    button.addEventListener('click', () => switchTriadPanel(button.dataset.target, button));
+  });
+
+  elements.toggleElimination.addEventListener('change', renderConsolidationMetrics);
+  elements.showEliminations.addEventListener('click', toggleEliminationList);
+
+  elements.thresholdRange.min = state.config.receivables.minDays;
+  elements.thresholdRange.max = state.config.receivables.maxDays;
+  elements.thresholdRange.addEventListener('input', (event) => {
+    state.threshold = Number(event.target.value);
+    elements.thresholdValue.textContent = state.threshold;
+    renderReceivables();
+  });
+
+  elements.sendToTraffic.addEventListener('click', addReceivablesToTraffic);
+
+  elements.cleanBalance.addEventListener('click', applyLiquidationScenario);
+  elements.trafficCompany.addEventListener('change', (event) => {
+    state.trafficCompany = event.target.value;
+    renderTrafficList();
+  });
+}
+
+function onDragOver(event) {
+  event.preventDefault();
+  elements.dropZone.classList.add('dragover');
+}
+
+function onDragLeave(event) {
+  event.preventDefault();
+  elements.dropZone.classList.remove('dragover');
+}
+
+function onDropFiles(event) {
+  event.preventDefault();
+  elements.dropZone.classList.remove('dragover');
+  const files = event.dataTransfer?.files;
+  if (files && files.length) {
+    handleFiles(files);
+  }
+}
+
+function handleFiles(fileList) {
+  state.lastUploadCount = fileList.length;
+  const scenario = chooseScenario(Array.from(fileList));
+  loadScenario(scenario, fileList.length);
+  elements.fileInput.value = '';
+}
+
+function chooseScenario(files) {
+  if (!files || !files.length) {
+    return state.data.uploadScenarios[0];
+  }
+  const hasZip = files.some((file) => file.name.toLowerCase().endsWith('.zip'));
+  if (hasZip) {
+    return state.data.uploadScenarios.find((item) => item.id === 'zipArchive') || state.data.uploadScenarios[0];
+  }
+  if (files.length > 20) {
+    return state.data.uploadScenarios.find((item) => item.id === 'groupUpload') || state.data.uploadScenarios[0];
+  }
+  return state.data.uploadScenarios.find((item) => item.id === 'singleCompany') || state.data.uploadScenarios[0];
+}
+
+function loadScenario(scenario, uploadedCount = 0) {
+  if (!scenario) {
+    return;
+  }
+  state.currentScenario = scenario;
+  state.mappingComplete = scenario.mappingSteps?.length === 0;
+  state.duplicateDecisions = new Map();
+  state.flaggedReceivables.clear();
+  state.inventoryFilters.clear();
+  state.liquidationCleaned = false;
+  state.threshold = state.config.receivables.defaultThreshold;
+  elements.thresholdRange.value = state.threshold;
+  elements.thresholdValue.textContent = state.threshold;
+  state.lastUploadCount = uploadedCount;
+  elements.trafficMessage.textContent = '';
+
+  elements.inventoryFilters.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+    checkbox.checked = false;
+  });
+
+  renderScenarioSummary();
+  renderGroupings();
+  renderAttentionList();
+  renderDuplicateList();
+  updateMappingButton();
+  updateStartButtonState();
+  resetScreensToUpload();
+  elements.triadNavButtons.forEach((btn, idx) => {
+    btn.setAttribute('aria-pressed', idx === 0 ? 'true' : 'false');
+  });
+  elements.eliminationDetails.setAttribute('hidden', '');
+  elements.showEliminations.textContent = 'Показать устранённые внутригрупповые обороты';
+  resetLiquidationView();
+  state.trafficFilter = 'all';
+  state.trafficCompany = 'all';
+  elements.trafficFilters.querySelectorAll('button').forEach((btn) => {
+    const active = btn.dataset.value === 'all';
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  elements.trafficCompany.value = 'all';
+  renderReceivables();
+  renderInventoryList();
+  renderTrafficList();
+}
+
+function renderScenarioSummary() {
+  const scenario = state.currentScenario;
+  elements.summaryFiles.textContent = scenario.summary.files;
+  elements.summaryCompanies.textContent = scenario.summary.companies;
+  elements.summaryPeriods.textContent = scenario.summary.periods;
+  elements.summaryFormats.textContent = scenario.summary.formats.join(' • ');
+  const uploadInfo = state.lastUploadCount ? `Загружено: ${state.lastUploadCount}` : 'Готовый демо-набор';
+  elements.summaryDescription.textContent = `${uploadInfo}. Сценарий: ${scenario.summary.description}.`;
+  elements.recognitionLegend.textContent = `Распознано: ${scenario.recognition.recognized} • Требует маппинга: ${scenario.recognition.needsMapping} • Дубликаты: ${scenario.recognition.duplicates}`;
+  elements.badgeFiles.textContent = `Файлов: ${scenario.summary.files}`;
+  elements.badgeCompanies.textContent = `Компаний: ${scenario.summary.companies}`;
+  elements.badgePeriods.textContent = `Периодов: ${scenario.summary.periods}`;
+  elements.badgeFormats.textContent = `Форматы: ${scenario.summary.formats.join(', ')}`;
+}
+
+function renderGroupings() {
+  const scenario = state.currentScenario;
+  renderCompanyGroups(scenario.files);
+  renderPeriodGroups(scenario.files);
+}
+
+function renderCompanyGroups(files) {
+  elements.companyFileList.innerHTML = '';
+  const companyMap = new Map();
+  files.forEach((file) => {
+    if (!companyMap.has(file.company)) {
+      companyMap.set(file.company, []);
+    }
+    companyMap.get(file.company).push(file);
+  });
+  companyMap.forEach((companyFiles, company) => {
+    const details = document.createElement('details');
+    details.className = 'file-group';
+    details.open = companyMap.size <= 4;
+    const summary = document.createElement('summary');
+    summary.textContent = `${company} • ${companyFiles.length} файлов`;
+    details.appendChild(summary);
+    companyFiles.forEach((file) => {
+      details.appendChild(createFileRow(file));
+    });
+    elements.companyFileList.appendChild(details);
+  });
+}
+
+function renderPeriodGroups(files) {
+  elements.periodFileList.innerHTML = '';
+  const yearMap = new Map();
+  files.forEach((file) => {
+    const year = file.period?.toString().slice(0, 4) || 'Не указан';
+    if (!yearMap.has(year)) {
+      yearMap.set(year, new Map());
+    }
+    const periodKey = file.periodLabel || file.period || 'Без периода';
+    const periodMap = yearMap.get(year);
+    if (!periodMap.has(periodKey)) {
+      periodMap.set(periodKey, []);
+    }
+    periodMap.get(periodKey).push(file);
+  });
+
+  yearMap.forEach((periodMap, year) => {
+    const details = document.createElement('details');
+    details.className = 'file-group';
+    details.open = yearMap.size <= 3;
+    const totalFiles = Array.from(periodMap.values()).reduce((acc, list) => acc + list.length, 0);
+    const summary = document.createElement('summary');
+    summary.textContent = `${year} • ${totalFiles} файлов`;
+    details.appendChild(summary);
+
+    periodMap.forEach((periodFiles, periodLabel) => {
+      const header = document.createElement('div');
+      header.className = 'file-row period-label';
+      const titleSpan = document.createElement('span');
+      titleSpan.textContent = periodLabel;
+      header.appendChild(titleSpan);
+      details.appendChild(header);
+      periodFiles.forEach((file) => {
+        details.appendChild(createFileRow(file));
+      });
+    });
+
+    elements.periodFileList.appendChild(details);
+  });
+}
+
+function createFileRow(file, options = {}) {
+  const row = document.createElement('div');
+  row.className = 'file-row';
+  const name = document.createElement('span');
+  name.textContent = file.name;
+  row.appendChild(name);
+
+  const type = document.createElement('span');
+  type.textContent = file.format ? `${file.type} (${file.format})` : file.type;
+  row.appendChild(type);
+
+  const period = document.createElement('span');
+  period.textContent = file.periodLabel || file.period || '—';
+  row.appendChild(period);
+
+  const origin = document.createElement('span');
+  origin.textContent = file.origin || '—';
+  row.appendChild(origin);
+
+  const status = document.createElement('span');
+  status.className = 'file-status';
+  status.dataset.status = file.status || 'recognized';
+  status.textContent = statusLabel(file.status);
+  row.appendChild(status);
+
+  if (file.mappingHint && options.showHint !== false) {
+    const hint = document.createElement('span');
+    hint.textContent = file.mappingHint;
+    hint.className = 'section-subtitle';
+    hint.style.gridColumn = '1 / -1';
+    row.appendChild(hint);
+  }
+
+  if (options.actions) {
+    const actionsContainer = document.createElement('div');
+    actionsContainer.className = 'file-actions';
+    actionsContainer.style.gridColumn = '1 / -1';
+    options.actions.forEach((actionButton) => {
+      actionsContainer.appendChild(actionButton);
+    });
+    row.appendChild(actionsContainer);
+  }
+
+  return row;
+}
+
+function statusLabel(status = 'recognized') {
+  const map = {
+    recognized: 'Распознано',
+    mapping: 'Нужен маппинг',
+    duplicate: 'Дубликат'
+  };
+  return map[status] || status;
+}
+
+function renderAttentionList() {
+  const scenario = state.currentScenario;
+  elements.attentionList.innerHTML = '';
+  const needsMapping = scenario.files.filter((file) => file.status === 'mapping');
+  if (!needsMapping.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Все файлы распознаны. Маппинг не требуется.';
+    elements.attentionList.appendChild(message);
+    return;
+  }
+  needsMapping.forEach((file) => {
+    elements.attentionList.appendChild(createFileRow(file));
+  });
+}
+
+function renderDuplicateList() {
+  const scenario = state.currentScenario;
+  elements.duplicateList.innerHTML = '';
+  const groups = scenario.duplicateResolutions || [];
+  if (!groups.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Дубликатов не найдено.';
+    elements.duplicateList.appendChild(message);
+    return;
+  }
+
+  groups.forEach((group) => {
+    const details = document.createElement('details');
+    details.className = 'file-group';
+    details.open = true;
+    const summary = document.createElement('summary');
+    summary.textContent = `Возможный дубликат: ${group.group}`;
+    details.appendChild(summary);
+
+    group.files.forEach((name) => {
+      const original = state.currentScenario.files.find((file) => file.name === name);
+      const fileRow = createFileRow(
+        original || {
+          name,
+          type: 'Отчёт',
+          periodLabel: '—',
+          origin: '—',
+          status: 'duplicate'
+        },
+        { showHint: false }
+      );
+      details.appendChild(fileRow);
+    });
+
+    const actionRow = document.createElement('div');
+    actionRow.className = 'file-row';
+    actionRow.style.gridTemplateColumns = '1fr';
+    const message = document.createElement('span');
+    message.id = `duplicate-msg-${group.group}`;
+    message.textContent = 'Выберите действие:';
+    actionRow.appendChild(message);
+
+    const actions = document.createElement('div');
+    actions.className = 'file-actions';
+
+    ['keepNew', 'keepOld', 'merge'].forEach((action) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'button-secondary';
+      button.dataset.action = action;
+      const labels = {
+        keepNew: 'Оставить новый',
+        keepOld: 'Оставить старый',
+        merge: 'Склеить'
+      };
+      button.textContent = labels[action];
+      button.addEventListener('click', () => handleDuplicateDecision(group, action));
+      actions.appendChild(button);
+    });
+
+    actionRow.appendChild(actions);
+    details.appendChild(actionRow);
+    elements.duplicateList.appendChild(details);
+  });
+}
+
+function handleDuplicateDecision(group, action) {
+  state.duplicateDecisions.set(group.group, action);
+  const message = document.getElementById(`duplicate-msg-${group.group}`);
+  if (message) {
+    message.textContent = group.messages[action];
+  }
+  const container = message?.parentElement?.querySelector('.file-actions');
+  if (container) {
+    container.querySelectorAll('button').forEach((btn) => {
+      btn.disabled = true;
+      btn.classList.toggle('button-primary', btn.dataset.action === action);
+    });
+  }
+  updateStartButtonState();
+}
+
+function updateMappingButton() {
+  const scenario = state.currentScenario;
+  if (!scenario || !scenario.mappingSteps || !scenario.mappingSteps.length) {
+    elements.startMapping.textContent = 'Маппинг не требуется';
+    elements.startMapping.disabled = true;
+    elements.startMapping.setAttribute('aria-disabled', 'true');
+  } else if (state.mappingComplete) {
+    elements.startMapping.textContent = 'Мастер пройден';
+    elements.startMapping.disabled = true;
+    elements.startMapping.setAttribute('aria-disabled', 'true');
+  } else {
+    elements.startMapping.textContent = 'Открыть мастер маппинга';
+    elements.startMapping.disabled = false;
+    elements.startMapping.removeAttribute('aria-disabled');
+  }
+}
+
+function updateStartButtonState() {
+  const scenarioReady = Boolean(state.currentScenario);
+  const duplicates = state.currentScenario?.duplicateResolutions || [];
+  const duplicatesResolved = duplicates.every((group) => state.duplicateDecisions.has(group.group)) || !duplicates.length;
+  const ready = scenarioReady && state.mappingComplete && duplicatesResolved;
+  elements.startConsolidation.disabled = !ready;
+}
+
+function resetScreensToUpload() {
+  elements.uploadScreen.classList.add('active');
+  elements.progressScreen.classList.remove('active');
+  elements.triadScreen.classList.remove('active');
+  elements.progressIndicator.style.width = '0%';
+  elements.progressValue.textContent = '0%';
+  elements.progressStatus.textContent = 'Подготовка';
+  elements.progressSteps.querySelectorAll('.progress-step').forEach((step, idx) => {
+    step.classList.toggle('active', idx === 0);
+  });
+}
+
+async function fetchJSON(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Не удалось загрузить ${path}`);
+  }
+  return response.json();
+}
+
+async function loadResources() {
+  try {
+    const [config, data] = await Promise.all([
+      fetchJSON('config.json'),
+      fetchJSON('assets/data/mockData.json')
+    ]);
+    return { config, data };
+  } catch (error) {
+    if (window.__FINASSIST_OFFLINE__?.config && window.__FINASSIST_OFFLINE__?.data) {
+      console.warn('Используем встроенные офлайн-данные', error);
+      return {
+        config: window.__FINASSIST_OFFLINE__.config,
+        data: window.__FINASSIST_OFFLINE__.data
+      };
+    }
+    console.error('Не удалось загрузить конфигурацию или данные', error);
+    return null;
+  }
+}
+
+function displayResourceLoadError() {
+  const message = 'Не удалось загрузить демо-данные. Откройте прототип через статический сервер или обновите страницу.';
+  elements.summaryDescription.textContent = message;
+  elements.recognitionLegend.textContent = 'Демо-набор недоступен.';
+  elements.summaryFiles.textContent = '0';
+  elements.summaryCompanies.textContent = '0';
+  elements.summaryPeriods.textContent = '0';
+  elements.summaryFormats.textContent = '—';
+}
+
+function openMappingWizard() {
+  const steps = state.currentScenario?.mappingSteps || [];
+  if (!steps.length) {
+    return;
+  }
+  let index = 0;
+  const backdrop = document.createElement('div');
+  backdrop.className = 'modal-backdrop';
+
+  const showStep = () => {
+    backdrop.innerHTML = '';
+    const fragment = elements.mappingTemplate.content.cloneNode(true);
+    const modal = fragment.querySelector('.modal');
+    const step = steps[index];
+    modal.querySelector('[data-role="title"]').textContent = step.title;
+    modal.querySelector('[data-role="description"]').textContent = step.description;
+    modal.querySelector('[data-role="suggestion"]').textContent = step.suggestion;
+    modal.querySelector('[data-role="cancel"]').addEventListener('click', () => {
+      document.body.removeChild(backdrop);
+    });
+    modal.querySelector('[data-role="confirm"]').addEventListener('click', () => {
+      index += 1;
+      if (index >= steps.length) {
+        state.mappingComplete = true;
+        document.body.removeChild(backdrop);
+        updateMappingButton();
+        updateStartButtonState();
+      } else {
+        showStep();
+      }
+    });
+    backdrop.appendChild(fragment);
+  };
+
+  document.body.appendChild(backdrop);
+  showStep();
+}
+
+function initializeProgressSteps() {
+  elements.progressSteps.innerHTML = '';
+  state.config.loading.stageLabels.forEach((label, idx) => {
+    const step = document.createElement('span');
+    step.className = 'progress-step';
+    if (idx === 0) {
+      step.classList.add('active');
+    }
+    step.textContent = label;
+    elements.progressSteps.appendChild(step);
+  });
+}
+
+function startConsolidation() {
+  if (!state.currentScenario) {
+    return;
+  }
+  elements.uploadScreen.classList.remove('active');
+  elements.progressScreen.classList.add('active');
+  state.progressStart = performance.now();
+  const min = state.config.loading.minSeconds * 1000;
+  const max = state.config.loading.maxSeconds * 1000;
+  state.progressDuration = Math.floor(Math.random() * (max - min + 1)) + min;
+  if (state.progressFrame) {
+    cancelAnimationFrame(state.progressFrame);
+  }
+  state.progressFrame = requestAnimationFrame(animateProgress);
+}
+
+function animateProgress(timestamp) {
+  const current = typeof timestamp === 'number' ? timestamp : performance.now();
+  const elapsed = current - state.progressStart;
+  const progress = Math.min(elapsed / state.progressDuration, 1);
+  elements.progressIndicator.style.width = `${Math.round(progress * 100)}%`;
+  elements.progressValue.textContent = `${Math.round(progress * 100)}%`;
+
+  const stages = elements.progressSteps.querySelectorAll('.progress-step');
+  const activeStage = Math.min(
+    stages.length - 1,
+    Math.floor(progress * stages.length)
+  );
+  stages.forEach((stage, idx) => {
+    stage.classList.toggle('active', idx === activeStage);
+  });
+  elements.progressStatus.textContent = state.config.loading.stageLabels[activeStage] || 'Обработка';
+
+  if (progress < 1) {
+    state.progressFrame = requestAnimationFrame(animateProgress);
+  } else {
+    completeProgress();
+  }
+}
+
+function completeProgress() {
+  state.progressFrame = null;
+  elements.progressScreen.classList.remove('active');
+  elements.triadScreen.classList.add('active');
+  renderConsolidationMetrics();
+  renderEliminationDetails();
+  renderHintsAndRules();
+  renderReceivables();
+  renderInventoryList();
+  renderLiquidation();
+  renderTrafficList();
+  switchTriadPanel('consolidation');
+}
+
+function renderConsolidationMetrics() {
+  const totals = state.currentScenario ? state.data.consolidation.totals : null;
+  if (!totals) {
+    return;
+  }
+  const useAfter = elements.toggleElimination.checked;
+  const selected = useAfter ? totals.after : totals.before;
+  const base = state.data.consolidation.baseSummary;
+  elements.consolidationMetrics.innerHTML = '';
+
+  const summaryCard = document.createElement('div');
+  summaryCard.className = 'metric-card';
+  summaryCard.innerHTML = `
+    <span class="metric-value">${base.companies}</span>
+    <span>Компаний в консолидированной базе</span>
+    <p class="metric-note">Файлов учтено: ${base.files}. Период: ${base.period}. Элиминаций: ${base.eliminatedPairs}.</p>
+  `;
+  elements.consolidationMetrics.appendChild(summaryCard);
+
+  const metrics = [
+    { key: 'revenue', label: 'Выручка' },
+    { key: 'cogs', label: 'Себестоимость' },
+    { key: 'grossMargin', label: 'Валовая маржа' },
+    { key: 'interestPayable', label: 'Проценты к уплате' },
+    { key: 'interestReceivable', label: 'Проценты к получению' }
+  ];
+
+  metrics.forEach((metric) => {
+    if (selected[metric.key] === undefined) {
+      return;
+    }
+    const card = document.createElement('div');
+    card.className = 'metric-card';
+    card.innerHTML = `
+      <span>${metric.label}</span>
+      <span class="metric-value">${formatCurrency(selected[metric.key])}</span>
+    `;
+    elements.consolidationMetrics.appendChild(card);
+  });
+
+  if (!useAfter) {
+    const intraCard = document.createElement('div');
+    intraCard.className = 'metric-card';
+    intraCard.innerHTML = `
+      <span>Внутригрупповая выручка</span>
+      <span class="metric-value">${formatCurrency(totals.before.intraRevenue)}</span>
+      <p class="metric-note">До элиминации остаётся в отчётности.</p>
+    `;
+    elements.consolidationMetrics.appendChild(intraCard);
+  }
+
+  if (selected.note) {
+    const note = document.createElement('p');
+    note.className = 'metric-note';
+    note.textContent = selected.note;
+    elements.consolidationMetrics.appendChild(note);
+  }
+}
+
+function renderEliminationDetails() {
+  const list = state.data.consolidation.eliminationEntries;
+  elements.eliminationDetails.innerHTML = '';
+  list.forEach((entry) => {
+    const item = document.createElement('div');
+    item.className = 'elimination-item';
+    item.innerHTML = `
+      <strong>${entry.pair}</strong>
+      <p class="section-subtitle">${entry.description}</p>
+      <p class="section-subtitle">${entry.metric}: ${formatCurrency(entry.amount)}</p>
+    `;
+    elements.eliminationDetails.appendChild(item);
+  });
+}
+
+function renderHintsAndRules() {
+  elements.consolidationHints.innerHTML = '';
+  state.data.consolidation.infoNotes.forEach((note) => {
+    const p = document.createElement('p');
+    p.textContent = note;
+    elements.consolidationHints.appendChild(p);
+  });
+  elements.consolidationRules.innerHTML = '';
+  state.data.consolidation.ruleHints.forEach((hint) => {
+    const p = document.createElement('p');
+    p.textContent = hint;
+    elements.consolidationRules.appendChild(p);
+  });
+}
+
+function toggleEliminationList() {
+  const hidden = elements.eliminationDetails.hasAttribute('hidden');
+  if (hidden) {
+    elements.eliminationDetails.removeAttribute('hidden');
+    elements.showEliminations.textContent = 'Скрыть устранённые обороты';
+  } else {
+    elements.eliminationDetails.setAttribute('hidden', '');
+    elements.showEliminations.textContent = 'Показать устранённые внутригрупповые обороты';
+  }
+}
+
+function renderReceivables() {
+  elements.receivablesList.innerHTML = '';
+  const threshold = state.threshold || state.config.receivables.defaultThreshold;
+  const list = state.data.detectors.receivables;
+  list.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'receivable-row';
+    const counterparty = document.createElement('span');
+    counterparty.textContent = `${item.counterparty} • ${item.company}`;
+    row.appendChild(counterparty);
+    const days = document.createElement('span');
+    days.textContent = `${item.days} дней`;
+    const highlight = getReceivableHighlight(item.days, threshold);
+    if (highlight) {
+      days.classList.add(highlight);
+    }
+    row.appendChild(days);
+    const amount = document.createElement('span');
+    amount.textContent = formatCurrency(item.amount);
+    if (highlight) {
+      amount.classList.add(highlight);
+    }
+    row.appendChild(amount);
+    const source = document.createElement('span');
+    source.textContent = item.source;
+    row.appendChild(source);
+    elements.receivablesList.appendChild(row);
+  });
+}
+
+function getReceivableHighlight(days, threshold) {
+  if (days >= threshold) {
+    return 'highlight-red';
+  }
+  if (days >= threshold - 30) {
+    return 'highlight-yellow';
+  }
+  return 'highlight-green';
+}
+
+function addReceivablesToTraffic() {
+  const threshold = state.threshold || state.config.receivables.defaultThreshold;
+  const list = state.data.detectors.receivables.filter((item) => item.days >= threshold);
+  list.forEach((item) => state.flaggedReceivables.add(item.counterparty));
+  elements.trafficMessage.textContent = list.length
+    ? `Добавлено в светофор: ${list.length}.`
+    : 'По текущему порогу просрочки нет.';
+  renderTrafficList();
+}
+
+function initializeInventoryFilters() {
+  if (!state.config) {
+    return;
+  }
+  elements.inventoryFilters.classList.add('inventory-filters');
+  elements.inventoryFilters.innerHTML = '';
+  state.config.inventoryMarkers.forEach((marker) => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = marker;
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        state.inventoryFilters.add(marker);
+      } else {
+        state.inventoryFilters.delete(marker);
+      }
+      renderInventoryList();
+    });
+    const span = document.createElement('span');
+    span.textContent = marker;
+    label.appendChild(checkbox);
+    label.appendChild(span);
+    elements.inventoryFilters.appendChild(label);
+  });
+}
+
+function renderInventoryList() {
+  elements.inventoryList.innerHTML = '';
+  const filters = state.inventoryFilters;
+  const list = state.data.detectors.inventory;
+  list.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'inventory-row';
+    const name = document.createElement('span');
+    name.textContent = `${item.item} • ${item.company}`;
+    row.appendChild(name);
+    const amount = document.createElement('span');
+    amount.textContent = formatCurrency(item.amount);
+    row.appendChild(amount);
+    const source = document.createElement('span');
+   source.textContent = item.source;
+   row.appendChild(source);
+   const flags = document.createElement('div');
+   flags.className = 'inventory-flags';
+   item.issues.forEach((issue) => {
+     const badge = document.createElement('span');
+     badge.textContent = issue;
+     flags.appendChild(badge);
+   });
+    flags.style.gridColumn = '1 / -1';
+    row.appendChild(flags);
+
+    if (!filters.size) {
+      highlightInventoryRow(row, item.issues);
+    } else if (item.issues.some((issue) => filters.has(issue))) {
+      highlightInventoryRow(row, item.issues);
+    }
+
+    elements.inventoryList.appendChild(row);
+  });
+}
+
+function highlightInventoryRow(row, issues) {
+  const severity = issues.includes('брак') || issues.includes('истёк срок') ? 'highlight-red' : 'highlight-yellow';
+  row.querySelectorAll('span').forEach((span) => span.classList.add(severity));
+}
+
+function resetLiquidationView() {
+  elements.liquidationAfterSummary.textContent = 'Нажмите «Очистить», чтобы применить сценарий.';
+  elements.ownerStatement.textContent = '';
+  elements.cleanBalance.disabled = false;
+  elements.cleanBalance.textContent = 'Очистить';
+  elements.liquidationAdjustments.innerHTML = '';
+  state.data.liquidation.adjustments.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = `${item.label}: ${formatCurrency(item.impact)} (${item.reason}, источник: ${item.source})`;
+    elements.liquidationAdjustments.appendChild(li);
+  });
+}
+
+function renderLiquidation() {
+  const data = state.data.liquidation;
+  elements.liquidationBeforeSummary.textContent = `Собственный капитал: ${formatCurrency(data.before.equity)} • Денежные средства: ${formatCurrency(data.before.cash)}`;
+  elements.liquidationAssets.innerHTML = '';
+  data.before.assets.forEach((asset) => {
+    const li = document.createElement('li');
+    li.textContent = `${asset.label}: ${formatCurrency(asset.amount)}`;
+    elements.liquidationAssets.appendChild(li);
+  });
+  if (state.liquidationCleaned) {
+    elements.liquidationAfterSummary.textContent = `Капитал после очистки: ${formatCurrency(data.after.equity)} • Денежный остаток: ${formatCurrency(data.after.cash)}`;
+    elements.ownerStatement.textContent = data.after.ownerStatement;
+  }
+}
+
+function applyLiquidationScenario() {
+  state.liquidationCleaned = true;
+  renderLiquidation();
+  elements.cleanBalance.disabled = true;
+  elements.cleanBalance.textContent = 'Очистка выполнена';
+}
+
+function initializeTrafficFilters() {
+  const labels = state.data.trafficLight.statusLabels;
+  elements.trafficFilters.innerHTML = '';
+  Object.entries(labels).forEach(([value, label]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'button-secondary';
+    button.textContent = label;
+    button.dataset.value = value;
+    if (value === 'all') {
+      button.classList.add('active');
+      button.setAttribute('aria-pressed', 'true');
+    } else {
+      button.setAttribute('aria-pressed', 'false');
+    }
+    button.addEventListener('click', () => {
+      state.trafficFilter = value;
+      elements.trafficFilters.querySelectorAll('button').forEach((btn) => {
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
+      });
+      button.classList.add('active');
+      button.setAttribute('aria-pressed', 'true');
+      renderTrafficList();
+    });
+    elements.trafficFilters.appendChild(button);
+  });
+}
+
+function initializeTrafficCompanies() {
+  const companies = new Set(['all']);
+  state.data.trafficLight.items.forEach((item) => companies.add(item.company));
+  elements.trafficCompany.innerHTML = '';
+  companies.forEach((company) => {
+    const option = document.createElement('option');
+    option.value = company;
+    option.textContent = company === 'all' ? 'Все компании' : company;
+    elements.trafficCompany.appendChild(option);
+  });
+  elements.trafficCompany.value = 'all';
+}
+
+function renderTrafficList() {
+  elements.trafficList.innerHTML = '';
+  const filter = state.trafficFilter;
+  const companyFilter = state.trafficCompany;
+  const flagged = state.flaggedReceivables;
+  state.data.trafficLight.items
+    .map((item) => {
+      const flaggedStatus = flagged.has(item.name) ? 'red' : item.status;
+      return { ...item, status: flaggedStatus, flagged: flagged.has(item.name) };
+    })
+    .filter((item) => (filter === 'all' ? true : item.status === filter))
+    .filter((item) => (companyFilter === 'all' ? true : item.company === companyFilter))
+    .forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'traffic-card';
+      const header = document.createElement('div');
+      header.innerHTML = `<strong>${item.name}</strong> • ${item.company}`;
+      card.appendChild(header);
+      const status = document.createElement('span');
+      status.className = 'status-pill';
+      status.dataset.status = item.status;
+      status.textContent = state.data.trafficLight.statusLabels[item.status] || item.status;
+      card.appendChild(status);
+      const financial = document.createElement('p');
+      financial.className = 'section-subtitle';
+      financial.textContent = item.financial;
+      card.appendChild(financial);
+      const legal = document.createElement('p');
+      legal.className = 'section-subtitle';
+      legal.textContent = item.legal;
+      card.appendChild(legal);
+      if (item.note) {
+        const note = document.createElement('p');
+        note.className = 'section-subtitle';
+        note.textContent = item.note;
+        card.appendChild(note);
+      }
+      if (item.flagged) {
+        const badge = document.createElement('p');
+        badge.className = 'section-subtitle';
+        badge.textContent = 'Добавлено из детектора дебиторки.';
+        card.appendChild(badge);
+      }
+      elements.trafficList.appendChild(card);
+    });
+  if (!elements.trafficList.children.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Нет контрагентов по выбранному фильтру.';
+    elements.trafficList.appendChild(message);
+  }
+}
+
+function switchTriadPanel(target, button) {
+  document.querySelectorAll('.triad-panel').forEach((panel) => {
+    panel.hidden = true;
+  });
+  document.getElementById(`panel-${target}`).hidden = false;
+  elements.triadNavButtons.forEach((btn) => btn.setAttribute('aria-pressed', 'false'));
+  if (button) {
+    button.setAttribute('aria-pressed', 'true');
+  } else {
+    const activeButton = Array.from(elements.triadNavButtons).find((btn) => btn.dataset.target === target);
+    if (activeButton) {
+      activeButton.setAttribute('aria-pressed', 'true');
+    }
+  }
+}
+
+function onTabKeydown(event) {
+  const tabs = [elements.tabCompanies, elements.tabPeriods];
+  const currentIndex = tabs.indexOf(event.target);
+  if (event.key === 'ArrowRight') {
+    const next = tabs[(currentIndex + 1) % tabs.length];
+    next.focus();
+    next.click();
+  } else if (event.key === 'ArrowLeft') {
+    const prev = tabs[(currentIndex - 1 + tabs.length) % tabs.length];
+    prev.focus();
+    prev.click();
+  }
+}
+
+function setActiveTab(tab) {
+  if (tab === 'companies') {
+    elements.tabCompanies.setAttribute('aria-selected', 'true');
+    elements.tabPeriods.setAttribute('aria-selected', 'false');
+    elements.panelCompanies.hidden = false;
+    elements.panelPeriods.hidden = true;
+  } else {
+    elements.tabCompanies.setAttribute('aria-selected', 'false');
+    elements.tabPeriods.setAttribute('aria-selected', 'true');
+    elements.panelCompanies.hidden = true;
+    elements.panelPeriods.hidden = false;
+  }
+}
+
+function renderFinalScreen() {
+  const summary = state.data.finalSummary;
+  elements.finalHeadline.textContent = summary.headline;
+  elements.finalPoints.innerHTML = '';
+  summary.points.forEach((point) => {
+    const li = document.createElement('li');
+    li.textContent = point;
+    elements.finalPoints.appendChild(li);
+  });
+  elements.finalDisclaimer.textContent = summary.disclaimer;
+}
+
+function updateCTA() {
+  if (state.config?.ctaUrl) {
+    elements.ctaButton.href = state.config.ctaUrl;
+  }
+}
+
+function formatCurrency(value) {
+  if (typeof value !== 'number') {
+    return value;
+  }
+  return `${numberFormatter.format(value)} ₽`;
+}

--- a/assets/js/offlineData.js
+++ b/assets/js/offlineData.js
@@ -1,0 +1,1186 @@
+// Автогенерированный файл для офлайн-режима.
+// Обновите вручную при изменении исходных JSON.
+
+window.__FINASSIST_OFFLINE__ = {
+  config: {
+  "ctaUrl": "https://solward.example/test-drive",
+  "loading": {
+    "minSeconds": 25,
+    "maxSeconds": 35,
+    "stageLabels": [
+      "Импорт",
+      "Нормализация",
+      "Сшивка",
+      "Проверки",
+      "Готово"
+    ]
+  },
+  "receivables": {
+    "defaultThreshold": 180,
+    "minDays": 100,
+    "maxDays": 270
+  },
+  "inventoryMarkers": [
+    "долго лежит",
+    "истёк срок",
+    "брак"
+  ]
+},
+  data: {
+  "uploadScenarios": [
+    {
+      "id": "singleCompany",
+      "label": "Одна компания, много файлов",
+      "summary": {
+        "companies": 1,
+        "files": 12,
+        "periods": 4,
+        "formats": [
+          "xlsx",
+          "csv"
+        ],
+        "description": "Разнобой периодов и форматов для одной компании"
+      },
+      "recognition": {
+        "recognized": 7,
+        "needsMapping": 3,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "ОСВ_январь.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "ОФР_Q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "ОФР_Q1_v2.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "баланс_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "запасы_февраль.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Сопоставить с классификатором запасов"
+        },
+        {
+          "name": "дебиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "кредиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHint": "Требуется указать тип отчёта"
+        },
+        {
+          "name": "движение_денег.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "инвентаризация_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Уточнить период учёта"
+        },
+        {
+          "name": "реестр_контрагентов.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "юрисобытия_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "архив_выручка_2022.xlsx",
+          "company": "Компания А",
+          "period": "2022",
+          "periodLabel": "2022",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распознала компанию по шапке файлов.",
+          "suggestion": "Компания А • ИНН 7701234567"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По заголовку файла предполагаем ОФР за период.",
+          "suggestion": "ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Подсказка из имени файла",
+          "suggestion": "I квартал 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "ОФР_Q1",
+          "files": [
+            "ОФР_Q1.csv",
+            "ОФР_Q1_v2.csv"
+          ],
+          "messages": {
+            "keepNew": "Новая версия сохранена. Предыдущая отправлена в архив.",
+            "keepOld": "Оставили исходный файл. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена. Строк объединено: 184."
+          }
+        }
+      ]
+    },
+    {
+      "id": "groupUpload",
+      "label": "Группа компаний, много файлов",
+      "summary": {
+        "companies": 3,
+        "files": 31,
+        "periods": 6,
+        "formats": [
+          "xlsx",
+          "csv",
+          "txt"
+        ],
+        "description": "Каждая компания прислала свою пачку"
+      },
+      "recognition": {
+        "recognized": 24,
+        "needsMapping": 5,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "Компания_A/OSV_jan.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/OSV_feb.xlsx",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/OSV_mar.xlsx",
+          "company": "Компания А",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/bal_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/pnl_q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "Компания_A/debt_q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_A/inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Нужно сопоставить коды ТМЦ"
+        },
+        {
+          "name": "Компания_A/legal_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/OSV_q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/pnl_q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/balance_31-03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_B/loans.txt",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "mappingHint": "Указать структуру колонок"
+        },
+        {
+          "name": "Компания_B/inventory_mar.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "склад"
+        },
+        {
+          "name": "Компания_B/debt_feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_B/legal_2024.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_C/osv_q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/pnl_q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/balance_31-03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_C/inventory_mar.csv",
+          "company": "Компания C",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "склад"
+        },
+        {
+          "name": "Компания_C/debt_mar.xlsx",
+          "company": "Компания C",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHint": "Проверить валюту"
+        },
+        {
+          "name": "Компания_C/contracts.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "Компания_C/legal_2024.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/pnl_feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_B_ОФР_Q1",
+          "origin": "альтернативная версия"
+        },
+        {
+          "name": "Компания_B/pnl_feb_v2.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_B_ОФР_Q1",
+          "origin": "альтернативная версия"
+        },
+        {
+          "name": "Компания_A/cashflow_q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_A/projects.txt",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "mappingHint": "Указать тип выгрузки"
+        },
+        {
+          "name": "Компания_B/receivables_jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_C/receivables_jan.xlsx",
+          "company": "Компания C",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_B/suppliers.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_A/suppliers.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_C/suppliers.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "закупки"
+        },
+        {
+          "name": "Компания_A/legal_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_B/legal_2023.csv",
+          "company": "Компания B",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_C/legal_2023.csv",
+          "company": "Компания C",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Из названия папки система определила группу.",
+          "suggestion": "Группа компаний АБВ"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По столбцам определён формат ОСВ.",
+          "suggestion": "ОСВ (на дату)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Предложенный период совпадает с заголовком.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Компания_B_ОФР_Q1",
+          "files": [
+            "Компания_B/pnl_feb.xlsx",
+            "Компания_B/pnl_feb_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Новая версия отчёта по Компании B сохранена.",
+            "keepOld": "Сохранили исходный отчёт. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена для Компании B. Строк объединено: 236."
+          }
+        }
+      ]
+    },
+    {
+      "id": "zipArchive",
+      "label": "ZIP-архив группы",
+      "summary": {
+        "companies": 3,
+        "files": 28,
+        "periods": 5,
+        "formats": [
+          "zip"
+        ],
+        "description": "Архив с вложенными папками компаний"
+      },
+      "recognition": {
+        "recognized": 21,
+        "needsMapping": 4,
+        "duplicates": 3
+      },
+      "files": [
+        {
+          "name": "group_upload.zip/Company_A/OSV_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/PnL_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Balance_31_03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Нужно подтвердить единицы измерения"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Receivables.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/OSV_2024_Q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Mar.xlsx",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Balance_31_03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Inventory_march.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Receivables.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/OSV_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/PnL_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Balance_31_03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Inventory_feb.csv",
+          "company": "Компания C",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Уточнить склад"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Receivables.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/security/events.csv",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/security/partners.xlsx",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/Company_A/cashflow.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/cashflow.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/cashflow.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/readme.txt",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/projects.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/Company_B/projects.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/Company_C/projects.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHint": "Укажите тип данных"
+        },
+        {
+          "name": "group_upload.zip/security/archive_2023.zip",
+          "company": "Группа",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "zip",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/loans.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Архив содержит подпапки по компаниям.",
+          "suggestion": "Компания А • Компания B • Компания C"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По структуре данных распознаны ОСВ и ОФР.",
+          "suggestion": "Баланс (на дату) и ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Выделен диапазон по именам файлов.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Company_B_PnL",
+          "files": [
+            "group_upload.zip/Company_B/PnL_Jan.xlsx",
+            "group_upload.zip/Company_B/PnL_Feb.xlsx",
+            "group_upload.zip/Company_B/PnL_Mar.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Сохранён последний файл за март, предыдущие помечены как исторические.",
+            "keepOld": "Сохранили январскую версию, остальные спрятаны в архив.",
+            "merge": "Объединение трёх файлов завершено. Строк объединено: 312."
+          }
+        }
+      ]
+    }
+  ],
+  "consolidation": {
+    "baseSummary": {
+      "companies": 5,
+      "files": 42,
+      "period": "I квартал 2024",
+      "eliminatedPairs": 8
+    },
+    "totals": {
+      "before": {
+        "revenue": 154000000,
+        "cogs": 112500000,
+        "grossMargin": 41500000,
+        "interestPayable": 2200000,
+        "interestReceivable": 2200000,
+        "intraRevenue": 11000000,
+        "intraCogs": 11000000,
+        "note": "До элиминации внутригрупповые обороты и проценты увеличивают обороты"
+      },
+      "after": {
+        "revenue": 143000000,
+        "cogs": 101500000,
+        "grossMargin": 41500000,
+        "interestPayable": 0,
+        "interestReceivable": 0,
+        "note": "Элиминации убрали внутригрупповую выручку и проценты"
+      }
+    },
+    "eliminationEntries": [
+      {
+        "pair": "Компания А → Компания B",
+        "description": "Поставка сырья",
+        "amount": 11000000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания B → Компания D",
+        "description": "Проценты по займу",
+        "amount": 2200000,
+        "metric": "Проценты к получению/уплате"
+      },
+      {
+        "pair": "Компания C ↔ Компания E",
+        "description": "Внутригрупповые услуги",
+        "amount": 3600000,
+        "metric": "Выручка/Прочие расходы"
+      },
+      {
+        "pair": "Компания А ↔ Компания C",
+        "description": "Расхождение по остаткам",
+        "amount": 1000000,
+        "metric": "Консервативная корректировка по большей сумме"
+      }
+    ],
+    "infoNotes": [
+      "Баланс — на дату. ОФР — за период. Аналогия: камера мгновенной и средней скорости.",
+      "Элиминации — снятие внутригрупповых оборотов для честного результата."
+    ],
+    "ruleHints": [
+      "Элиминация процентов к уплате и к получению по внутригрупповым займам.",
+      "Консервативная корректировка: при расхождениях берём большую сумму.",
+      "Правило баланса: нет двойного учёта между дочерними компаниями."
+    ]
+  },
+  "detectors": {
+    "receivables": [
+      {
+        "counterparty": "Торговый дом \"Север\"",
+        "company": "Компания А",
+        "days": 210,
+        "amount": 4200000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Метеор\"",
+        "company": "Компания B",
+        "days": 275,
+        "amount": 3200000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ЗАО \"Партнёр\"",
+        "company": "Компания C",
+        "days": 165,
+        "amount": 1800000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "ИП Сафронов",
+        "company": "Компания D",
+        "days": 95,
+        "amount": 950000,
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "counterparty": "АО \"Логистика\"",
+        "company": "Компания Е",
+        "days": 188,
+        "amount": 2400000,
+        "source": "дебиторка_Q1.xlsx"
+      }
+    ],
+    "inventory": [
+      {
+        "item": "Партия кабеля КБ-14",
+        "company": "Компания B",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 1250000,
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "item": "Компоненты серии X17",
+        "company": "Компания А",
+        "issues": [
+          "истёк срок"
+        ],
+        "amount": 840000,
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "item": "Готовая продукция L2",
+        "company": "Компания C",
+        "issues": [
+          "брак",
+          "долго лежит"
+        ],
+        "amount": 1560000,
+        "source": "inventory_mar.csv"
+      },
+      {
+        "item": "Материалы проекта R",
+        "company": "Компания D",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 610000,
+        "source": "inventory_mar.csv"
+      }
+    ],
+    "legend": {
+      "receivables": "Дебиторка",
+      "inventory": "Запасы"
+    }
+  },
+  "liquidation": {
+    "before": {
+      "equity": 72000000,
+      "cash": 18500000,
+      "assets": [
+        {
+          "label": "Дебиторская задолженность",
+          "amount": 32500000
+        },
+        {
+          "label": "Запасы",
+          "amount": 26800000
+        },
+        {
+          "label": "Основные средства",
+          "amount": 54000000
+        }
+      ]
+    },
+    "adjustments": [
+      {
+        "label": "Списание дебитора ООО \"Метеор\"",
+        "impact": -3200000,
+        "reason": ">270 дней без оплаты",
+        "source": "дебиторка_Q1.xlsx"
+      },
+      {
+        "label": "Списание партии КБ-14",
+        "impact": -1250000,
+        "reason": "неликвид > 9 месяцев",
+        "source": "запасы_февраль.csv"
+      },
+      {
+        "label": "Дисконт готовой продукции L2",
+        "impact": -780000,
+        "reason": "брак, продажа с уценкой",
+        "source": "inventory_mar.csv"
+      }
+    ],
+    "after": {
+      "equity": 52000000,
+      "cash": 41000000,
+      "ownerStatement": "Оценка: при продаже бизнеса собственник получит около 41 млн руб. живыми деньгами."
+    }
+  },
+  "trafficLight": {
+    "statusLabels": {
+      "all": "Все",
+      "green": "Зелёные",
+      "yellow": "Жёлтые",
+      "red": "Красные"
+    },
+    "items": [
+      {
+        "name": "ООО \"Форвард\"",
+        "company": "Компания А",
+        "status": "green",
+        "financial": "Платёж дисциплинирован, оборачиваемость 35 дней.",
+        "legal": "Нет активных судебных дел.",
+        "note": "Допустимый лимит 12 млн руб."
+      },
+      {
+        "name": "АО \"Логистика\"",
+        "company": "Компания Е",
+        "status": "yellow",
+        "financial": "Рост просрочки до 45 дней.",
+        "legal": "Имеется исполнительное производство на небольшую сумму.",
+        "note": "Рекомендация: запросить обновлённые документы."
+      },
+      {
+        "name": "ООО \"Метеор\"",
+        "company": "Компания B",
+        "status": "red",
+        "financial": "Просрочка 275 дней, выручка снижается.",
+        "legal": "Сообщение о намерении банкротства.",
+        "note": "Поставки остановлены, требуется контроль."
+      },
+      {
+        "name": "ЗАО \"Партнёр\"",
+        "company": "Компания C",
+        "status": "yellow",
+        "financial": "Просрочка 165 дней, частичные платежи.",
+        "legal": "Претензионная работа без суда.",
+        "note": "Дополнительное согласование скидок."
+      },
+      {
+        "name": "ИП Сафронов",
+        "company": "Компания D",
+        "status": "green",
+        "financial": "Оплата вовремя, обороты стабильны.",
+        "legal": "Нет событий.",
+        "note": "Можно расширить лимит до 5 млн руб."
+      }
+    ]
+  },
+  "finalSummary": {
+    "headline": "Минуты вместо дней. Минимум ручного труда. Триада готова.",
+    "points": [
+      "Файлы собраны, нормализованы и сведены в одну базу.",
+      "Проблемные зоны подсвечены автоматически.",
+      "Команда видит, где действовать первой."
+    ],
+    "disclaimer": "Демонстрационный прототип. Данные и расчёты упрощены."
+  }
+}
+};

--- a/config.json
+++ b/config.json
@@ -1,0 +1,24 @@
+{
+  "ctaUrl": "https://solward.example/test-drive",
+  "loading": {
+    "minSeconds": 25,
+    "maxSeconds": 35,
+    "stageLabels": [
+      "Импорт",
+      "Нормализация",
+      "Сшивка",
+      "Проверки",
+      "Готово"
+    ]
+  },
+  "receivables": {
+    "defaultThreshold": 180,
+    "minDays": 100,
+    "maxDays": 270
+  },
+  "inventoryMarkers": [
+    "долго лежит",
+    "истёк срок",
+    "брак"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Интерактивная триада Solward — демонстрационный прототип</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <a class="visually-hidden" href="#main-content">Перейти к содержимому</a>
+    <div class="app">
+      <header>
+        <h1>Интерактивная триада: консолидация → ликвидационный баланс → светофор</h1>
+        <p>
+          Прототип демонстрирует процесс: мультизагрузка файлов, нормализация и итоговые отчёты.
+          Интерфейс показывает проблемные зоны фактически, без лозунгов.
+        </p>
+        <div class="summary-badges" role="status" aria-live="polite">
+          <span class="badge" id="badge-files">Файлов: 0</span>
+          <span class="badge" id="badge-companies">Компаний: 0</span>
+          <span class="badge" id="badge-periods">Периодов: 0</span>
+          <span class="badge" id="badge-formats">Форматы: —</span>
+        </div>
+      </header>
+      <main id="main-content">
+        <section id="upload-screen" class="screen active" aria-labelledby="upload-title">
+          <div class="section-title">
+            <div>
+              <h2 id="upload-title">Загрузка и нормализация данных</h2>
+              <p class="section-subtitle">
+                Поддерживается drag&drop папок и отдельных файлов. Система показывает, что распознано,
+                где требуется уточнение и какие есть дубликаты.
+              </p>
+            </div>
+            <button id="demoScenario" class="button-secondary" type="button">
+              Использовать демо-набор
+            </button>
+          </div>
+          <div class="drop-zone" id="dropZone" role="button" tabindex="0" aria-describedby="dropHint">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M12 3L7 8h3v4h4V8h3l-5-5z"
+                stroke="var(--accent)"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M5 15v2a2 2 0 002 2h10a2 2 0 002-2v-2"
+                stroke="var(--accent)"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <p id="dropHint">Перетащите файлы или папку сюда, либо выберите вручную.</p>
+            <div class="input-file button-primary">
+              <span>Выбрать файлы</span>
+              <input id="fileInput" type="file" multiple webkitdirectory aria-label="Выберите файлы" />
+            </div>
+            <small class="section-subtitle">
+              Поддерживаются форматы xlsx, csv, zip и смешанные наборы. Все расчёты выполняются локально.
+            </small>
+          </div>
+          <div class="upload-summary" aria-live="polite">
+            <article class="summary-card">
+              <strong id="summary-files">0</strong>
+              <span>Всего файлов</span>
+              <p id="summary-description" class="section-subtitle"></p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-companies">0</strong>
+              <span>Компаний</span>
+              <p id="recognition-legend" class="section-subtitle">
+                Распознано: 0 • Требует маппинга: 0 • Дубликаты: 0
+              </p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-periods">0</strong>
+              <span>Периодов</span>
+              <p class="section-subtitle">Показываем, где не хватает данных</p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-formats">—</strong>
+              <span>Форматы</span>
+              <p class="section-subtitle">xlsx • csv • zip</p>
+            </article>
+          </div>
+          <div class="tablist" role="tablist" aria-label="Группировка файлов">
+            <button role="tab" id="tab-companies" aria-selected="true" aria-controls="panel-companies">
+              По компаниям
+            </button>
+            <button role="tab" id="tab-periods" aria-selected="false" aria-controls="panel-periods">
+              По периодам
+            </button>
+          </div>
+          <div id="panel-companies" role="tabpanel" aria-labelledby="tab-companies">
+            <div class="file-list" id="companyFileList" aria-live="polite"></div>
+          </div>
+          <div id="panel-periods" role="tabpanel" aria-labelledby="tab-periods" hidden>
+            <div class="file-list" id="periodFileList" aria-live="polite"></div>
+          </div>
+          <div class="section-title">
+            <div>
+              <h3 class="section-subtitle">Файлы, требующие внимания</h3>
+              <p class="section-subtitle">
+                Подтвердите подсказки системы, чтобы перейти к консолидации. Все предположения уже заполнены.
+              </p>
+            </div>
+            <button id="startMapping" type="button" class="button-secondary" disabled>
+              Открыть мастер маппинга
+            </button>
+          </div>
+          <div class="file-list" id="attentionList" aria-live="polite"></div>
+          <div class="section-title">
+            <div>
+              <h3 class="section-subtitle">Дубликаты</h3>
+              <p class="section-subtitle">Выберите действие для каждого дубликата — оставить, архивировать или склеить.</p>
+            </div>
+          </div>
+          <div class="file-list" id="duplicateList" aria-live="polite"></div>
+          <div class="section-title">
+            <div>
+              <h3 class="section-subtitle">Готово к старту</h3>
+              <p class="section-subtitle">После подтверждения начнётся имитация консолидации и проверок.</p>
+            </div>
+            <button id="startConsolidation" class="button-primary" type="button" disabled>
+              Начать консолидацию
+            </button>
+          </div>
+        </section>
+
+        <section id="progress-screen" class="screen" aria-labelledby="progress-title">
+          <div class="section-title">
+            <div>
+              <h2 id="progress-title">Консолидация запущена</h2>
+              <p class="section-subtitle">Имитация обработки занимает около 30 секунд.</p>
+            </div>
+          </div>
+          <div class="progress-container">
+            <div class="progress-bar" aria-hidden="true">
+              <span id="progressIndicator"></span>
+            </div>
+            <div id="progressValue" aria-live="polite">0%</div>
+            <div class="progress-steps" id="progressSteps" aria-hidden="true"></div>
+            <p class="section-subtitle" id="progressStatus">Подготовка</p>
+          </div>
+        </section>
+
+        <section id="triad-screen" class="screen" aria-labelledby="triad-title">
+          <div class="section-title">
+            <div>
+              <h2 id="triad-title">Триада готова</h2>
+              <p class="section-subtitle">Быстрый переход между консолидированными отчётами и детекторами рисков.</p>
+            </div>
+          </div>
+          <nav class="triad-nav" aria-label="Экран триады">
+            <button type="button" class="triad-nav-btn" data-target="consolidation" aria-pressed="true">
+              Консолидация
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="detectors" aria-pressed="false">
+              Детекторы
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="liquidation" aria-pressed="false">
+              Ликвидационный баланс
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="traffic" aria-pressed="false">
+              Светофор
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="final" aria-pressed="false">
+              Итог
+            </button>
+          </nav>
+          <div id="triad-panels">
+            <div id="panel-consolidation" class="triad-panel" role="region" aria-labelledby="triad-title">
+              <div class="metrics-grid" id="consolidationMetrics"></div>
+              <label class="toggle">
+                <input type="checkbox" id="toggleElimination" checked />
+                <span>Показать элиминации внутригрупповых оборотов</span>
+              </label>
+              <button id="showEliminations" class="button-secondary" type="button">
+                Показать устранённые внутригрупповые обороты
+              </button>
+              <div id="eliminationDetails" class="elimination-list" hidden></div>
+              <aside class="info-hints" id="consolidationHints"></aside>
+              <aside class="info-hints" id="consolidationRules"></aside>
+            </div>
+            <div id="panel-detectors" class="triad-panel" role="region" hidden>
+              <div class="detectors-grid">
+                <div class="detector-panel" aria-labelledby="receivable-title">
+                  <div>
+                    <h3 id="receivable-title">Неработающая задолженность</h3>
+                    <p class="section-subtitle">
+                      Управляйте порогом по дням. Всё, что выше порога, подсвечивается и может быть отправлено в светофор.
+                    </p>
+                  </div>
+                  <div class="range-control">
+                    <label for="thresholdRange">Порог дней</label>
+                    <input type="range" id="thresholdRange" min="100" max="270" value="180" />
+                    <span id="thresholdValue">180</span>
+                  </div>
+                  <div id="receivablesList"></div>
+                  <button id="sendToTraffic" class="button-secondary" type="button">
+                    Отправить в светофор
+                  </button>
+                  <p class="section-subtitle" id="trafficMessage" aria-live="polite"></p>
+                </div>
+                <div class="detector-panel" aria-labelledby="inventory-title">
+                  <div>
+                    <h3 id="inventory-title">Запасы и неликвид</h3>
+                    <p class="section-subtitle">
+                      Отметьте признаки, чтобы подсветить спорные позиции. Запасы и дебиторка — главные зоны внимания.
+                    </p>
+                  </div>
+                  <div id="inventoryFilters"></div>
+                  <div id="inventoryList"></div>
+                </div>
+              </div>
+            </div>
+            <div id="panel-liquidation" class="triad-panel" role="region" hidden>
+              <div class="section-title">
+                <div>
+                  <h3 class="section-subtitle">Очистка баланса от мусора</h3>
+                  <p class="section-subtitle">Показываем, сколько денег останется у собственника при продаже бизнеса.</p>
+                </div>
+                <button id="cleanBalance" class="button-primary" type="button">Очистить</button>
+              </div>
+              <div class="liquidation-layout">
+                <div class="liquidation-card">
+                  <h3>До очистки</h3>
+                  <p class="section-subtitle" id="liquidationBeforeSummary"></p>
+                  <ul id="liquidationAssets"></ul>
+                </div>
+                <div class="liquidation-card">
+                  <h3>Сценарные списания</h3>
+                  <ul id="liquidationAdjustments"></ul>
+                </div>
+                <div class="liquidation-card">
+                  <h3>После очистки</h3>
+                  <p class="section-subtitle" id="liquidationAfterSummary"></p>
+                  <p id="ownerStatement"></p>
+                </div>
+              </div>
+            </div>
+            <div id="panel-traffic" class="triad-panel" role="region" hidden>
+              <div class="traffic-controls">
+                <div role="group" aria-label="Фильтр статуса" id="trafficFilters"></div>
+                <label for="trafficCompany">Компания</label>
+                <select id="trafficCompany" aria-label="Фильтр по компании">
+                  <option value="all">Все компании</option>
+                </select>
+              </div>
+              <div class="traffic-list" id="trafficList"></div>
+            </div>
+            <div id="panel-final" class="triad-panel final-screen" role="region" hidden>
+              <h3 id="finalHeadline"></h3>
+              <ul id="finalPoints"></ul>
+              <p class="disclaimer" id="finalDisclaimer"></p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+    <a id="ctaButton" class="cta-floating" href="#" target="_blank" rel="noopener">Записаться на тест-драйв</a>
+    <template id="mappingStepTemplate">
+      <div class="modal" role="dialog" aria-modal="true" aria-live="polite">
+        <h3 data-role="title"></h3>
+        <p data-role="description"></p>
+        <p><strong data-role="suggestion"></strong></p>
+        <div class="modal-actions">
+          <button type="button" class="button-secondary" data-role="cancel">Позже</button>
+          <button type="button" class="button-primary" data-role="confirm">Подтвердить</button>
+        </div>
+      </div>
+    </template>
+    <script src="assets/js/offlineData.js" defer></script>
+    <script src="assets/js/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add an embedded offline data bundle and load it when fetching JSON assets fails so the demo scenario button works without a server
- gate the demo scenario control until resources are ready, fall back to an inline error message, and guard the click handler
- style disabled buttons for clearer feedback and include the offline bundle in the HTML entry point
- move `index.html` and the `/assets` directory to the repository root so Vercel can serve the prototype without extra configuration
- update the configuration fetch path to `config.json` after relocating the static files

## Testing
- python -m json.tool config.json
- python -m json.tool assets/data/mockData.json

------
https://chatgpt.com/codex/tasks/task_e_68d399221cec83298c41a0d7c800564e