### PR TITLE
Split signal report panel into inner tabs

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,1578 @@
+:root {
+  --bg-color: #0f172a;
+  --bg-gradient: radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(96, 165, 250, 0.12), transparent 55%),
+    var(--bg-color);
+  --surface-elevated: linear-gradient(145deg, rgba(17, 28, 52, 0.88), rgba(12, 19, 35, 0.92));
+  --surface-panel: rgba(15, 23, 42, 0.65);
+  --surface-card: rgba(15, 23, 42, 0.55);
+  --surface-muted: rgba(15, 23, 42, 0.4);
+  --surface-highlight: rgba(8, 47, 73, 0.35);
+  --surface-pill: rgba(148, 163, 184, 0.18);
+  --surface-soft: rgba(148, 163, 184, 0.12);
+  --surface-warning: rgba(250, 204, 21, 0.18);
+  --surface-danger: rgba(248, 113, 113, 0.18);
+  --border-color: rgba(148, 163, 184, 0.25);
+  --border-color-strong: rgba(148, 163, 184, 0.35);
+  --border-color-soft: rgba(148, 163, 184, 0.12);
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.12);
+  --accent-strong: #0284c7;
+  --accent-contrast: #0f172a;
+  --text-color: #f8fafc;
+  --muted: #94a3b8;
+  --danger: #f87171;
+  --warning: #facc15;
+  --success: #4ade80;
+  --border-radius: 16px;
+  --transition: 0.3s ease;
+  --panel-padding: clamp(16px, 2vw, 32px);
+}
+
+body[data-theme='light'] {
+  --bg-color: #f8fafc;
+  --bg-gradient: radial-gradient(circle at top left, rgba(191, 219, 254, 0.45), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(186, 230, 253, 0.4), transparent 50%),
+    var(--bg-color);
+  --surface-elevated: linear-gradient(145deg, #ffffff, #f1f5f9);
+  --surface-panel: #ffffff;
+  --surface-card: #f8fafc;
+  --surface-muted: #e2e8f0;
+  --surface-highlight: rgba(191, 219, 254, 0.45);
+  --surface-pill: rgba(56, 189, 248, 0.15);
+  --surface-soft: rgba(148, 163, 184, 0.25);
+  --surface-warning: rgba(250, 204, 21, 0.22);
+  --surface-danger: rgba(248, 113, 113, 0.22);
+  --border-color: rgba(148, 163, 184, 0.35);
+  --border-color-strong: rgba(148, 163, 184, 0.55);
+  --border-color-soft: rgba(148, 163, 184, 0.2);
+  --shadow: 0 18px 35px rgba(15, 23, 42, 0.14);
+  --accent-contrast: #082f49;
+  --text-color: #0f172a;
+  --muted: #475569;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.visually-hidden {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+}
+
+.app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 48px) clamp(12px, 4vw, 48px) 120px;
+}
+
+header {
+  display: grid;
+  gap: 16px;
+  margin-bottom: clamp(20px, 4vw, 48px);
+}
+
+.header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.header-text {
+  display: grid;
+  gap: 8px;
+  max-width: 720px;
+}
+
+.header-text h1 {
+  font-size: clamp(28px, 3vw, 44px);
+  margin: 0;
+  font-weight: 700;
+}
+
+.header-text p {
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(16px, 2vw, 18px);
+}
+
+.summary-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge {
+  background: var(--surface-panel);
+  border: 1px solid var(--border-color-strong);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+main {
+  display: grid;
+  gap: clamp(16px, 3vw, 32px);
+}
+
+.screen {
+  display: none;
+  background: var(--surface-elevated);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow);
+  padding: var(--panel-padding);
+}
+
+.screen.active {
+  display: block;
+}
+
+.screen header {
+  margin-bottom: 16px;
+}
+
+.section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.section-title h2 {
+  margin: 0;
+  font-size: clamp(22px, 2.5vw, 32px);
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 16px;
+  color: var(--muted);
+}
+
+.subtle-note {
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.drop-zone {
+  border: 1.5px dashed rgba(56, 189, 248, 0.5);
+  border-radius: var(--border-radius);
+  padding: clamp(32px, 4vw, 64px);
+  text-align: center;
+  background: var(--surface-highlight);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
+.drop-zone.dragover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.drop-zone button,
+.button-primary,
+.button-secondary,
+.button-ghost {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 12px;
+  padding: 12px 20px;
+  border: none;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.button-primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+}
+
+.button-primary:hover,
+.button-primary:focus {
+  background: var(--accent-strong);
+  outline: none;
+}
+
+.button-secondary {
+  background: var(--surface-muted);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+}
+
+.button-secondary:hover,
+.button-secondary:focus {
+  background: var(--surface-soft);
+}
+
+.button-primary:disabled,
+.button-secondary:disabled,
+.button-ghost:disabled,
+.drop-zone button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.button-ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+}
+
+.button-ghost:hover,
+.button-ghost:focus {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-muted);
+  color: var(--text-color);
+  padding: 10px 16px;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  outline: none;
+}
+
+.theme-toggle[aria-pressed='true'] {
+  color: var(--accent-strong);
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.theme-toggle__icon {
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.theme-toggle__label {
+  font-size: 14px;
+}
+
+.input-file {
+  position: relative;
+  overflow: hidden;
+}
+
+.input-file input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.upload-summary {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 24px;
+}
+
+.summary-card {
+  background: var(--surface-panel);
+  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid var(--border-color);
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.summary-card strong {
+  font-size: 28px;
+}
+
+.summary-card span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.tablist {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.tablist button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--muted);
+}
+
+.tablist button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tablist button[aria-selected="true"] {
+  background: var(--accent-soft);
+  color: var(--text-color);
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.upload-tabs {
+  margin-top: 32px;
+  display: grid;
+  gap: 20px;
+}
+
+.upload-tabpanel {
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  background: var(--surface-panel);
+  padding: clamp(20px, 3vw, 32px);
+  display: grid;
+  gap: 16px;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.18);
+}
+
+.upload-tabpanel .section-subtitle {
+  margin: 0;
+}
+
+.upload-tabpanel .file-list {
+  margin-top: 0;
+}
+
+.file-list {
+  margin-top: 16px;
+  display: grid;
+  gap: 20px;
+}
+
+.file-list > * {
+  align-self: start;
+}
+
+.upload-divider {
+  margin-top: 32px;
+}
+
+.file-group {
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+}
+
+.file-group summary {
+  cursor: pointer;
+  list-style: none;
+  margin: 0;
+  padding: 18px 22px;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--text-color);
+  background: var(--surface-highlight);
+}
+
+.file-group summary::-webkit-details-marker {
+  display: none;
+}
+
+.file-group[open] summary {
+  border-bottom: 1px solid var(--border-color-soft);
+}
+
+.file-group__body {
+  display: grid;
+  gap: 16px;
+  padding: 18px 22px 22px;
+}
+
+.file-group[open] {
+  grid-column: 1 / -1;
+}
+
+.file-group[open] .file-group__body:not(.period-grid) {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+}
+
+.file-group:not([open]) .file-group__body {
+  display: none;
+}
+
+.file-group__body .file-row,
+.file-group__body .file-card {
+  background: var(--surface-muted);
+  border-color: var(--border-color-soft);
+  box-shadow: none;
+}
+
+@media (min-width: 1280px) {
+  .file-list {
+    grid-template-columns: repeat(2, minmax(360px, 1fr));
+  }
+}
+
+@media (min-width: 1600px) {
+  .file-list {
+    grid-template-columns: repeat(3, minmax(320px, 1fr));
+  }
+}
+
+.upload-actions {
+  margin-top: 32px;
+  position: sticky;
+  bottom: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+  z-index: 5;
+}
+
+.upload-actions__info {
+  flex: 1 1 260px;
+  min-width: 220px;
+  display: grid;
+  gap: 4px;
+}
+
+.upload-actions__info h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.upload-actions__info p {
+  margin: 0;
+}
+
+.upload-actions__buttons {
+  flex: 1 1 260px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.upload-actions__buttons .button-primary,
+.upload-actions__buttons .button-secondary {
+  min-width: 180px;
+}
+
+@media (min-width: 1024px) {
+  .upload-actions {
+    margin-right: 160px;
+  }
+}
+
+.file-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.25);
+  display: block;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.file-card--expandable {
+  overflow: hidden;
+}
+
+.file-card__summary {
+  padding: 18px 22px;
+  display: grid;
+  gap: 12px;
+  background: var(--surface-card);
+  border-bottom: 1px solid var(--border-color-soft);
+}
+
+.file-card--expandable .file-card__summary {
+  cursor: pointer;
+}
+
+.file-card__summary--static {
+  cursor: default;
+}
+
+.file-card summary {
+  list-style: none;
+}
+
+.file-card summary::-webkit-details-marker {
+  display: none;
+}
+
+.file-card__top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.file-card__top--expandable {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.file-card__name {
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.file-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.file-card__caret {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg);
+  transition: transform var(--transition);
+}
+
+.file-card[open] .file-card__caret {
+  transform: rotate(225deg);
+}
+
+
+.file-card__body {
+  padding: 22px 24px 24px;
+  display: grid;
+  gap: 18px;
+  background: var(--surface-muted);
+  border-top: 1px solid var(--border-color-soft);
+}
+
+.file-card__hints {
+  display: grid;
+  gap: 12px;
+}
+
+.file-card__hint {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+  line-height: 1.45;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.18);
+}
+
+.file-card[open] {
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.28);
+  grid-column: 1 / -1;
+}
+
+.file-card[open] .file-card__summary {
+  background: var(--surface-card);
+}
+
+.file-card[open] .file-card__body {
+  width: min(100%, 960px);
+  margin: 0 auto;
+}
+
+
+.file-card--expandable:not([open]) .file-card__summary {
+  border-bottom-color: var(--border-color);
+}
+
+.file-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 2.4fr) repeat(4, minmax(120px, 1fr));
+  gap: 12px;
+  padding: 16px;
+  align-items: flex-start;
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.25);
+}
+
+.file-row span {
+  font-size: 14px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.file-row--compact {
+  grid-template-columns: minmax(200px, 1.6fr) repeat(3, minmax(120px, 1fr));
+  padding: 14px;
+  gap: 10px;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.18);
+}
+
+.period-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .period-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+}
+
+.period-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.22);
+}
+
+.period-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.period-card__header h4 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.period-card__header .section-subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.period-card__list {
+  display: grid;
+  gap: 12px;
+}
+
+.period-card__list .file-row {
+  background: var(--surface-muted);
+  border-color: var(--border-color-soft);
+  box-shadow: none;
+}
+
+.file-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: var(--surface-highlight);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: var(--text-color);
+}
+
+.file-tag--type {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.file-tag--period {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.file-tag--origin {
+  background: rgba(94, 234, 212, 0.2);
+  border-color: rgba(94, 234, 212, 0.45);
+}
+
+.file-row--compact .file-tag {
+  justify-self: start;
+}
+
+.file-status {
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  min-width: 140px;
+}
+
+.file-status[data-status="recognized"] {
+  background: rgba(74, 222, 128, 0.2);
+  border-color: rgba(74, 222, 128, 0.4);
+  color: #166534;
+}
+
+.file-status[data-status="mapping"] {
+  background: rgba(250, 204, 21, 0.25);
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #854d0e;
+}
+
+.file-status[data-status="duplicate"] {
+  background: rgba(148, 163, 184, 0.25);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-color);
+}
+
+.file-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.elimination-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 20px;
+  align-items: center;
+}
+
+.elimination-button {
+  padding-inline: 18px;
+}
+
+.duplicate-section-title {
+  margin: 16px 0 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.duplicate-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.24);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.duplicate-card--resolved {
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25), 0 16px 34px rgba(15, 23, 42, 0.18);
+}
+
+.duplicate-summary {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 14px;
+  grid-column: 1 / -1;
+}
+
+.duplicate-summary__note {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--accent);
+}
+
+.duplicate-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.duplicate-card__status {
+  margin-left: auto;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-contrast);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.duplicate-card--resolved .duplicate-card__status {
+  background: rgba(74, 222, 128, 0.16);
+  color: var(--success);
+}
+
+.duplicate-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.duplicate-card__more {
+  font-style: italic;
+}
+
+.duplicate-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.duplicate-card__button {
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+.duplicate-card__button--active {
+  background: var(--accent-soft);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+}
+
+.duplicate-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.duplicate-card__note {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.progress-container {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 12px;
+  background: var(--surface-soft);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), #60a5fa);
+  transition: width 0.2s ease;
+}
+
+.progress-steps {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.progress-step {
+  background: var(--surface-panel);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 13px;
+  border: 1px solid var(--border-color);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.progress-step.active {
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+}
+
+.triad-nav {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.triad-nav button {
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-panel);
+  color: var(--muted);
+}
+
+.triad-nav button[aria-pressed="true"] {
+  color: var(--text-color);
+  border-color: rgba(56, 189, 248, 0.6);
+  background: var(--accent-soft);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.metric-card {
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.metric-card .metric-value {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.metric-note {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.elimination-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.elimination-item {
+  border-radius: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  padding: 14px;
+  background: var(--surface-highlight);
+}
+
+.info-hints {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.info-hints p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.detector-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.detector-tab-btn {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-color);
+  padding: 10px 20px;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition),
+    box-shadow var(--transition);
+}
+
+.detector-tab-btn:hover,
+.detector-tab-btn:focus {
+  border-color: var(--accent);
+  box-shadow: 0 12px 28px rgba(56, 189, 248, 0.25);
+  outline: none;
+}
+
+.detector-tab-btn[aria-pressed='true'] {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.32);
+}
+
+.detector-panels {
+  display: grid;
+  gap: 24px;
+}
+
+.detector-panel {
+  background: var(--surface-card);
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  padding: 20px;
+  display: grid;
+  gap: 20px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.28);
+  width: 100%;
+}
+
+.detector-panel h3 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.detector-panel > div:first-child {
+  display: grid;
+  gap: 8px;
+}
+
+.range-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--surface-muted);
+  border: 1px solid var(--border-color-soft);
+}
+
+.range-control input[type="range"] {
+  flex: 1;
+}
+
+#receivablesList,
+#inventoryList {
+  display: grid;
+  gap: 12px;
+}
+
+.receivable-row,
+.inventory-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.6fr) minmax(120px, 1fr) minmax(140px, 1fr) minmax(140px, 1fr);
+  gap: 12px;
+  padding: 16px;
+  background: var(--surface-card);
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.22);
+}
+
+.receivable-row span,
+.inventory-row span {
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.highlight-red,
+.highlight-yellow,
+.highlight-green {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.highlight-red {
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.2);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+}
+
+.highlight-yellow {
+  color: #854d0e;
+  background: rgba(250, 204, 21, 0.22);
+  border: 1px solid rgba(250, 204, 21, 0.4);
+}
+
+.highlight-green {
+  color: #166534;
+  background: rgba(74, 222, 128, 0.22);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+}
+
+.inventory-flags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+}
+
+.inventory-flags span {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  border: 1px solid var(--border-color-soft);
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.inventory-row--warning {
+  border-color: rgba(250, 204, 21, 0.55);
+  background: linear-gradient(145deg, rgba(250, 204, 21, 0.18), rgba(250, 204, 21, 0.08));
+}
+
+.inventory-row--critical {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: linear-gradient(145deg, rgba(248, 113, 113, 0.24), rgba(248, 113, 113, 0.12));
+}
+
+.inventory-row--warning .inventory-flags span,
+.inventory-row--critical .inventory-flags span {
+  background: rgba(15, 23, 42, 0.4);
+  color: #fff;
+  border-color: transparent;
+}
+
+.inventory-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.inventory-filters label {
+  position: relative;
+  display: inline-flex;
+  border-radius: 999px;
+  border: none;
+  background: none;
+}
+
+.inventory-filters label input[type="checkbox"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.inventory-filters label span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-card);
+  font-size: 13px;
+  color: var(--text-color);
+  transition: border-color var(--transition), background var(--transition), color var(--transition), box-shadow var(--transition);
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.22);
+}
+
+.inventory-filters label input[type="checkbox"]:focus-visible + span {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.inventory-filters label input[type="checkbox"]:checked + span {
+  background: var(--accent-soft);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.liquidation-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.liquidation-card {
+  background: var(--surface-card);
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.liquidation-card h3 {
+  margin: 0;
+}
+
+.liquidation-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.traffic-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.traffic-controls select {
+  background: var(--surface-panel);
+  color: var(--text-color);
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  padding: 8px 12px;
+}
+
+.traffic-controls button.active {
+  background: var(--accent-soft);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text-color);
+}
+
+.traffic-list {
+  margin-top: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.traffic-card {
+  background: var(--surface-card);
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-pill[data-status="green"] {
+  background: rgba(74, 222, 128, 0.18);
+  color: var(--success);
+}
+
+.status-pill[data-status="yellow"] {
+  background: rgba(250, 204, 21, 0.18);
+  color: var(--warning);
+}
+
+.status-pill[data-status="red"] {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--danger);
+}
+
+.final-screen {
+  text-align: center;
+  display: grid;
+  gap: 16px;
+}
+
+.final-screen ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.final-screen li {
+  background: var(--surface-panel);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 12px 16px;
+}
+
+.disclaimer {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.cta-floating {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-radius: 999px;
+  padding: 16px 24px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
+  border: none;
+  transition: transform var(--transition), background var(--transition);
+  z-index: 1000;
+}
+
+.cta-floating:hover,
+.cta-floating:focus {
+  background: var(--accent-strong);
+  transform: translateY(-4px);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 900;
+}
+
+.modal {
+  background: var(--surface-elevated);
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  padding: 24px;
+  width: min(90vw, 520px);
+  display: grid;
+  gap: 16px;
+}
+
+.modal h3 {
+  margin: 0;
+}
+
+.modal p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.modal-list {
+  display: grid;
+  gap: 14px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.modal-step {
+  background: var(--surface-muted);
+  border: 1px solid var(--border-color-soft);
+  border-radius: 12px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.modal-options {
+  display: grid;
+  gap: 12px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.modal-option {
+  background: var(--surface-muted);
+  border: 1px solid var(--border-color-soft);
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-color);
+  transition: transform var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.modal-option:hover,
+.modal-option:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  background: rgba(56, 189, 248, 0.16);
+  transform: translateY(-2px);
+}
+
+.modal-option__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.modal-option__description {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.modal-option--manual {
+  border-style: dashed;
+}
+
+.modal-step h4 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--text-color);
+}
+
+.modal-suggestion {
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 1024px) {
+  .file-row {
+    grid-template-columns: minmax(200px, 2fr) repeat(2, minmax(140px, 1fr));
+  }
+
+  .file-row .file-status {
+    justify-self: flex-start;
+  }
+
+  .receivable-row,
+  .inventory-row {
+    grid-template-columns: minmax(160px, 1.2fr) minmax(120px, 1fr) minmax(120px, 1fr);
+  }
+
+  .receivable-row span:last-child,
+  .inventory-row span:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding-bottom: 140px;
+  }
+
+  header {
+    text-align: left;
+  }
+
+  .header-top {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .theme-toggle {
+    align-self: flex-start;
+  }
+
+  .upload-actions {
+    position: static;
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px;
+    gap: 12px;
+  }
+
+  .upload-actions__buttons {
+    justify-content: stretch;
+  }
+
+  .upload-actions__buttons .button-primary,
+  .upload-actions__buttons .button-secondary {
+    width: 100%;
+  }
+
+  .file-row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .file-row span {
+    word-break: break-word;
+  }
+
+  .file-row .file-status {
+    justify-self: flex-start;
+  }
+
+  .file-actions {
+    grid-column: 1 / -1;
+  }
+
+  .receivable-row,
+  .inventory-row {
+    grid-template-columns: minmax(160px, 1fr) minmax(140px, 1fr);
+  }
+
+  .receivable-row span:nth-child(3),
+  .receivable-row span:nth-child(4),
+  .inventory-row span:nth-child(2),
+  .inventory-row span:nth-child(3) {
+    grid-column: 1 / -1;
+  }
+
+  .inventory-flags {
+    grid-column: 1 / -1;
+  }
+
+  .cta-floating {
+    left: 16px;
+    right: 16px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .drop-zone {
+    padding: 24px;
+  }
+
+  .summary-card {
+    min-height: auto;
+  }
+
+  .triad-nav {
+    flex-direction: column;
+  }
+
+  .triad-nav button {
+    width: 100%;
+  }
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -25,6 +25,12 @@
   --danger: #f87171;
   --warning: #facc15;
   --success: #4ade80;
+  --traffic-green-bg: rgba(74, 222, 128, 0.16);
+  --traffic-green-border: rgba(74, 222, 128, 0.45);
+  --traffic-yellow-bg: rgba(250, 204, 21, 0.16);
+  --traffic-yellow-border: rgba(250, 204, 21, 0.45);
+  --traffic-red-bg: rgba(248, 113, 113, 0.16);
+  --traffic-red-border: rgba(248, 113, 113, 0.45);
   --border-radius: 16px;
   --transition: 0.3s ease;
   --panel-padding: clamp(16px, 2vw, 32px);
@@ -51,6 +57,12 @@ body[data-theme='light'] {
   --accent-contrast: #082f49;
   --text-color: #0f172a;
   --muted: #475569;
+  --traffic-green-bg: rgba(34, 197, 94, 0.18);
+  --traffic-green-border: rgba(34, 197, 94, 0.4);
+  --traffic-yellow-bg: rgba(250, 204, 21, 0.22);
+  --traffic-yellow-border: rgba(250, 204, 21, 0.4);
+  --traffic-red-bg: rgba(248, 113, 113, 0.24);
+  --traffic-red-border: rgba(248, 113, 113, 0.45);
 }
 
 * {
@@ -1253,6 +1265,17 @@ main {
   align-items: center;
 }
 
+#trafficFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.traffic-filter-btn {
+  padding: 8px 18px;
+  font-size: 14px;
+}
+
 .traffic-controls select {
   background: var(--surface-panel);
   color: var(--text-color);
@@ -1261,16 +1284,11 @@ main {
   padding: 8px 12px;
 }
 
-.traffic-controls button.active {
-  background: var(--accent-soft);
-  border-color: rgba(56, 189, 248, 0.6);
-  color: var(--text-color);
-}
-
 .traffic-list {
   margin-top: 16px;
   display: grid;
   gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .traffic-card {
@@ -1280,6 +1298,25 @@ main {
   padding: 16px;
   display: grid;
   gap: 8px;
+  transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.traffic-card[data-status='green'] {
+  background: var(--traffic-green-bg);
+  border-color: var(--traffic-green-border);
+  box-shadow: 0 16px 32px rgba(74, 222, 128, 0.18);
+}
+
+.traffic-card[data-status='yellow'] {
+  background: var(--traffic-yellow-bg);
+  border-color: var(--traffic-yellow-border);
+  box-shadow: 0 16px 32px rgba(250, 204, 21, 0.18);
+}
+
+.traffic-card[data-status='red'] {
+  background: var(--traffic-red-bg);
+  border-color: var(--traffic-red-border);
+  box-shadow: 0 16px 32px rgba(248, 113, 113, 0.18);
 }
 
 .status-pill {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1674,6 +1674,16 @@ main {
   }
 }
 
+@media (max-width: 600px) {
+  .triad-nav {
+    flex-direction: column;
+  }
+
+  .triad-nav button {
+    width: 100%;
+  }
+}
+
 @media (max-width: 480px) {
   .drop-zone {
     padding: 24px;
@@ -1681,13 +1691,5 @@ main {
 
   .summary-card {
     min-height: auto;
-  }
-
-  .triad-nav {
-    flex-direction: column;
-  }
-
-  .triad-nav button {
-    width: 100%;
   }
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -669,27 +669,71 @@ main {
   background: var(--surface-card);
   border: 1px solid var(--border-color);
   border-radius: 16px;
-  padding: 18px;
-  display: grid;
-  gap: 12px;
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .period-card__header {
   display: flex;
-  justify-content: space-between;
   align-items: baseline;
-  gap: 10px;
+  gap: 12px;
+  padding: 18px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.period-card__header::-webkit-details-marker {
+  display: none;
+}
+
+.period-card__header::marker {
+  content: '';
 }
 
 .period-card__header h4 {
   margin: 0;
   font-size: 18px;
+  flex: 1;
 }
 
 .period-card__header .section-subtitle {
   margin: 0;
+  margin-left: auto;
   color: var(--muted);
+  white-space: nowrap;
+}
+
+.period-card__chevron {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(-45deg);
+  transition: transform 0.2s ease;
+  margin-left: 12px;
+  align-self: center;
+}
+
+.period-card[open] .period-card__chevron {
+  transform: rotate(135deg);
+}
+
+.period-card[open] {
+  border-color: var(--accent);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.28);
+}
+
+.period-card__header:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.period-card__content {
+  display: grid;
+  gap: 12px;
+  padding: 0 18px 18px;
+  border-top: 1px solid var(--border-color-soft);
 }
 
 .period-card__list {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1540,20 +1540,37 @@ main {
   }
 
   .upload-actions {
-    position: static;
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    bottom: 24px;
     flex-direction: column;
     align-items: stretch;
-    padding: 16px;
+    padding: 16px 18px;
     gap: 12px;
   }
 
+  .upload-actions__info {
+    gap: 2px;
+  }
+
+  .upload-actions__info p {
+    display: none;
+  }
+
+  .upload-actions__info h3 {
+    font-size: 16px;
+  }
+
   .upload-actions__buttons {
+    width: 100%;
     justify-content: stretch;
   }
 
   .upload-actions__buttons .button-primary,
   .upload-actions__buttons .button-secondary {
     width: 100%;
+    min-width: 0;
   }
 
   .file-row {
@@ -1571,6 +1588,46 @@ main {
 
   .file-actions {
     grid-column: 1 / -1;
+  }
+
+  .file-card__summary {
+    padding: 16px 18px;
+  }
+
+  .file-card__top {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'name'
+      'status';
+    gap: 10px;
+    align-items: flex-start;
+  }
+
+  .file-card__top .file-card__name {
+    grid-area: name;
+  }
+
+  .file-card__top .file-status {
+    grid-area: status;
+    justify-self: flex-start;
+  }
+
+  .file-card__top--expandable {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'name caret'
+      'status status';
+  }
+
+  .file-card__top--expandable .file-card__caret {
+    grid-area: caret;
+    justify-self: flex-end;
+  }
+
+  .file-card__tags {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
   }
 
   .receivable-row,

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -473,57 +473,48 @@ main {
   }
 }
 
-.upload-actions {
-  margin-top: 32px;
-  position: sticky;
-  bottom: 24px;
-  display: flex;
-  flex-wrap: wrap;
+
+.workflow-fab {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  z-index: 20;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 20px 24px;
-  background: var(--surface-elevated);
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
+  justify-content: center;
+  gap: 8px;
+  padding: 14px 24px;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.2;
   box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
-  z-index: 5;
+  cursor: pointer;
+  transition: box-shadow var(--transition), background var(--transition);
 }
 
-.upload-actions__info {
-  flex: 1 1 260px;
-  min-width: 220px;
-  display: grid;
-  gap: 4px;
+.workflow-fab:hover,
+.workflow-fab:focus-visible {
+  background: var(--accent-strong);
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.35);
+  outline: none;
 }
 
-.upload-actions__info h3 {
-  margin: 0;
-  font-size: 18px;
+.workflow-fab:disabled,
+.workflow-fab[aria-disabled='true'] {
+  background: var(--surface-disabled);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
-.upload-actions__info p {
-  margin: 0;
-}
-
-.upload-actions__buttons {
-  flex: 1 1 260px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: flex-end;
-}
-
-.upload-actions__buttons .button-primary,
-.upload-actions__buttons .button-secondary {
-  min-width: 180px;
-}
-
-@media (min-width: 1024px) {
-  .upload-actions {
-    margin-right: 160px;
-  }
+.workflow-fab:disabled:hover,
+.workflow-fab[aria-disabled='true']:hover {
+  background: var(--surface-disabled);
+  box-shadow: none;
 }
 
 .file-card {
@@ -1370,28 +1361,6 @@ main {
   color: var(--muted);
 }
 
-.cta-floating {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  background: var(--accent);
-  color: var(--accent-contrast);
-  border-radius: 999px;
-  padding: 16px 24px;
-  font-weight: 600;
-  text-decoration: none;
-  box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
-  border: none;
-  transition: transform var(--transition), background var(--transition);
-  z-index: 1000;
-}
-
-.cta-floating:hover,
-.cta-floating:focus {
-  background: var(--accent-strong);
-  transform: translateY(-4px);
-}
-
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -1521,10 +1490,6 @@ main {
 }
 
 @media (max-width: 768px) {
-  .app {
-    padding-bottom: 140px;
-  }
-
   header {
     text-align: left;
   }
@@ -1539,38 +1504,19 @@ main {
     align-self: flex-start;
   }
 
-  .upload-actions {
-    position: fixed;
-    left: 16px;
-    right: 16px;
+  .app {
+    padding-bottom: 96px;
+  }
+
+  .workflow-fab {
+    left: 50%;
+    right: auto;
     bottom: 24px;
-    flex-direction: column;
-    align-items: stretch;
-    padding: 16px 18px;
-    gap: 12px;
-  }
-
-  .upload-actions__info {
-    gap: 2px;
-  }
-
-  .upload-actions__info p {
-    display: none;
-  }
-
-  .upload-actions__info h3 {
-    font-size: 16px;
-  }
-
-  .upload-actions__buttons {
-    width: 100%;
-    justify-content: stretch;
-  }
-
-  .upload-actions__buttons .button-primary,
-  .upload-actions__buttons .button-secondary {
-    width: 100%;
-    min-width: 0;
+    width: calc(100% - 48px);
+    max-width: 320px;
+    transform: translateX(-50%);
+    padding: 14px 20px;
+    font-size: 15px;
   }
 
   .file-row {
@@ -1646,11 +1592,6 @@ main {
     grid-column: 1 / -1;
   }
 
-  .cta-floating {
-    left: 16px;
-    right: 16px;
-    text-align: center;
-  }
 }
 
 @media (max-width: 480px) {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -662,12 +662,7 @@ main {
 .period-grid {
   display: grid;
   gap: 16px;
-}
-
-@media (min-width: 960px) {
-  .period-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  }
+  grid-template-columns: 1fr;
 }
 
 .period-card {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1633,6 +1633,47 @@ main {
 
 }
 
+@media (max-width: 600px) {
+  .detector-tabs {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .detector-tab-btn {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .detector-panels {
+    gap: 16px;
+  }
+
+  .detector-panel {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .range-control {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .receivable-row,
+  .inventory-row {
+    grid-template-columns: 1fr;
+  }
+
+  .receivable-row span,
+  .inventory-row span {
+    grid-column: 1 / -1;
+  }
+
+  .inventory-flags {
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 480px) {
   .drop-zone {
     padding: 24px;

--- a/assets/data/mockData.json
+++ b/assets/data/mockData.json
@@ -1,0 +1,4696 @@
+{
+  "uploadScenarios": [
+    {
+      "id": "singleCompany",
+      "label": "Одна компания, много файлов",
+      "summary": {
+        "companies": 1,
+        "files": 12,
+        "periods": 4,
+        "formats": [
+          "xlsx",
+          "csv"
+        ],
+        "description": "Разнобой периодов и форматов для одной компании"
+      },
+      "recognition": {
+        "recognized": 7,
+        "needsMapping": 3,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "ОСВ_январь.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "ОФР_Q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "ОФР_Q1_v2.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "баланс_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "запасы_февраль.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Сопоставить с классификатором запасов",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Дополните справочник подразделений для новых кодов",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "дебиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "кредиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHints": [
+            "Требуется указать тип отчёта",
+            "Дополните справочник подразделений для новых кодов",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "движение_денег.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "инвентаризация_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Уточнить период учёта",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "реестр_контрагентов.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "юрисобытия_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "архив_выручка_2022.xlsx",
+          "company": "Компания А",
+          "period": "2022",
+          "periodLabel": "2022",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распознала компанию по шапке файлов.",
+          "suggestion": "Компания А • ИНН 7701234567"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По заголовку файла предполагаем ОФР за период.",
+          "suggestion": "ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Подсказка из имени файла",
+          "suggestion": "I квартал 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "ОФР_Q1",
+          "files": [
+            "ОФР_Q1.csv",
+            "ОФР_Q1_v2.csv"
+          ],
+          "messages": {
+            "keepNew": "Новая версия сохранена. Предыдущая отправлена в архив.",
+            "keepOld": "Оставили исходный файл. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена. Строк объединено: 184."
+          }
+        }
+      ]
+    },
+    {
+      "id": "groupUpload",
+      "label": "Группа компаний, много файлов",
+      "summary": {
+        "companies": 60,
+        "files": 331,
+        "periods": 16,
+        "formats": [
+          "csv",
+          "txt",
+          "xlsx"
+        ],
+        "description": "60 компаний, более 300 файлов и разные форматы выгрузок"
+      },
+      "recognition": {
+        "recognized": 272,
+        "needsMapping": 53,
+        "duplicates": 6
+      },
+      "files": [
+        {
+          "name": "Компания_01/OSV_2024_Q1.xlsx",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_01/PnL_2024_Q1.csv",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_01/Balance_20240331.xlsx",
+          "company": "Компания 01",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_01/Receivables_2024_Q1.xlsx",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_02/OSV_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_02/PnL_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_02/Balance_20240630.xlsx",
+          "company": "Компания 02",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_02/Receivables_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_02/Inventory_2024_05.csv",
+          "company": "Компания 02",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_03/OSV_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_03/PnL_2023_Q4.csv",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_03/Balance_20231231.xlsx",
+          "company": "Компания 03",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_03/Receivables_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_03/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_04/OSV_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_04/PnL_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_04/Balance_20230930.xlsx",
+          "company": "Компания 04",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_04/Receivables_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_04/Inventory_2023_08.csv",
+          "company": "Компания 04",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Привяжите показатели к управленческой статье движения",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_04/Projects_2023.csv",
+          "company": "Компания 04",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_05/OSV_2024_Q1.xlsx",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_05/PnL_2024_Q1.csv",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_05/Balance_20240331.xlsx",
+          "company": "Компания 05",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_05/Receivables_2024_Q1.xlsx",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_05/Legal_2024.csv",
+          "company": "Компания 05",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_06/OSV_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_06/PnL_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_06/Balance_20240630.xlsx",
+          "company": "Компания 06",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_06/Receivables_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_06/Inventory_2024_05.csv",
+          "company": "Компания 06",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_06/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_07/OSV_2023_Q4.xlsx",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_07/PnL_2023_Q4.csv",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_07/Balance_20231231.xlsx",
+          "company": "Компания 07",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_07/Receivables_2023_Q4.xlsx",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_07/Loans_2023_10.txt",
+          "company": "Компания 07",
+          "period": "2023-10",
+          "periodLabel": "Октябрь 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_08/OSV_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_08/PnL_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_08/Balance_20230930.xlsx",
+          "company": "Компания 08",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_08/Receivables_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_08/Inventory_2023_08.csv",
+          "company": "Компания 08",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_08/Projects_2023.csv",
+          "company": "Компания 08",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Дополните справочник подразделений для новых кодов",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_09/OSV_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_09/PnL_2024_Q1.csv",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_09/Balance_20240331.xlsx",
+          "company": "Компания 09",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_09/Receivables_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_09/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_10/OSV_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_10/PnL_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_10/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_10_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_10/Balance_20240630.xlsx",
+          "company": "Компания 10",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_10/Receivables_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_10/Inventory_2024_05.csv",
+          "company": "Компания 10",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_10/Legal_2024.csv",
+          "company": "Компания 10",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_11/OSV_2023_Q4.xlsx",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_11/PnL_2023_Q4.csv",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_11/Balance_20231231.xlsx",
+          "company": "Компания 11",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_11/Receivables_2023_Q4.xlsx",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/OSV_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_12/PnL_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/Balance_20230930.xlsx",
+          "company": "Компания 12",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_12/Receivables_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/Inventory_2023_08.csv",
+          "company": "Компания 12",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_12/Projects_2023.csv",
+          "company": "Компания 12",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_12/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_13/OSV_2024_Q1.xlsx",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_13/PnL_2024_Q1.csv",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_13/Balance_20240331.xlsx",
+          "company": "Компания 13",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_13/Receivables_2024_Q1.xlsx",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_14/OSV_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_14/PnL_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_14/Balance_20240630.xlsx",
+          "company": "Компания 14",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_14/Receivables_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_14/Inventory_2024_05.csv",
+          "company": "Компания 14",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_14/Loans_2024_04.txt",
+          "company": "Компания 14",
+          "period": "2024-04",
+          "periodLabel": "Апрель 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_15/OSV_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_15/PnL_2023_Q4.csv",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_15/Balance_20231231.xlsx",
+          "company": "Компания 15",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_15/Receivables_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_15/Legal_2023.csv",
+          "company": "Компания 15",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_15/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_16/OSV_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_16/PnL_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_16/Balance_20230930.xlsx",
+          "company": "Компания 16",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_16/Receivables_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_16/Inventory_2023_08.csv",
+          "company": "Компания 16",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Уточните источник данных — файл собран вручную",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_16/Projects_2023.csv",
+          "company": "Компания 16",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_17/OSV_2024_Q1.xlsx",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_17/PnL_2024_Q1.csv",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_17/Balance_20240331.xlsx",
+          "company": "Компания 17",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_17/Receivables_2024_Q1.xlsx",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/OSV_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_18/PnL_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/Balance_20240630.xlsx",
+          "company": "Компания 18",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_18/Receivables_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/Inventory_2024_05.csv",
+          "company": "Компания 18",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_18/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_19/OSV_2023_Q4.xlsx",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_19/PnL_2023_Q4.csv",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_19/Balance_20231231.xlsx",
+          "company": "Компания 19",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_19/Receivables_2023_Q4.xlsx",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_20/OSV_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_20/PnL_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_20/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_20_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_20/Balance_20230930.xlsx",
+          "company": "Компания 20",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_20/Receivables_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_20/Inventory_2023_08.csv",
+          "company": "Компания 20",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Дополните справочник подразделений для новых кодов",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_20/Projects_2023.csv",
+          "company": "Компания 20",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Уточните источник данных — файл собран вручную",
+            "Привяжите показатели к управленческой статье движения",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_20/Legal_2023.csv",
+          "company": "Компания 20",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_21/OSV_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_21/PnL_2024_Q1.csv",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_21/Balance_20240331.xlsx",
+          "company": "Компания 21",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_21/Receivables_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_21/Loans_2024_01.txt",
+          "company": "Компания 21",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Привяжите показатели к управленческой статье движения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_21/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_22/OSV_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_22/PnL_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_22/Balance_20240630.xlsx",
+          "company": "Компания 22",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_22/Receivables_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_22/Inventory_2024_05.csv",
+          "company": "Компания 22",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Уточните источник данных — файл собран вручную",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_23/OSV_2023_Q4.xlsx",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_23/PnL_2023_Q4.csv",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_23/Balance_20231231.xlsx",
+          "company": "Компания 23",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_23/Receivables_2023_Q4.xlsx",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/OSV_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_24/PnL_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/Balance_20230930.xlsx",
+          "company": "Компания 24",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_24/Receivables_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/Inventory_2023_08.csv",
+          "company": "Компания 24",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Уточните источник данных — файл собран вручную",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_24/Projects_2023.csv",
+          "company": "Компания 24",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Уточните источник данных — файл собран вручную",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_24/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_25/OSV_2024_Q1.xlsx",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_25/PnL_2024_Q1.csv",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_25/Balance_20240331.xlsx",
+          "company": "Компания 25",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_25/Receivables_2024_Q1.xlsx",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_25/Legal_2024.csv",
+          "company": "Компания 25",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_26/OSV_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_26/PnL_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_26/Balance_20240630.xlsx",
+          "company": "Компания 26",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_26/Receivables_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_26/Inventory_2024_05.csv",
+          "company": "Компания 26",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_27/OSV_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_27/PnL_2023_Q4.csv",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_27/Balance_20231231.xlsx",
+          "company": "Компания 27",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_27/Receivables_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_27/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_28/OSV_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_28/PnL_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_28/Balance_20230930.xlsx",
+          "company": "Компания 28",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_28/Receivables_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_28/Inventory_2023_08.csv",
+          "company": "Компания 28",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_28/Projects_2023.csv",
+          "company": "Компания 28",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_28/Loans_2023_07.txt",
+          "company": "Компания 28",
+          "period": "2023-07",
+          "periodLabel": "Июль 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_29/OSV_2024_Q1.xlsx",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_29/PnL_2024_Q1.csv",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_29/Balance_20240331.xlsx",
+          "company": "Компания 29",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_29/Receivables_2024_Q1.xlsx",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/OSV_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_30/PnL_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_30_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_30/Balance_20240630.xlsx",
+          "company": "Компания 30",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_30/Receivables_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/Inventory_2024_05.csv",
+          "company": "Компания 30",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Уточните источник данных — файл собран вручную",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_30/Legal_2024.csv",
+          "company": "Компания 30",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_30/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_31/OSV_2023_Q4.xlsx",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_31/PnL_2023_Q4.csv",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_31/Balance_20231231.xlsx",
+          "company": "Компания 31",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_31/Receivables_2023_Q4.xlsx",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_32/OSV_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_32/PnL_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_32/Balance_20230930.xlsx",
+          "company": "Компания 32",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_32/Receivables_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_32/Inventory_2023_08.csv",
+          "company": "Компания 32",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_32/Projects_2023.csv",
+          "company": "Компания 32",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_33/OSV_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_33/PnL_2024_Q1.csv",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_33/Balance_20240331.xlsx",
+          "company": "Компания 33",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_33/Receivables_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_33/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_34/OSV_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_34/PnL_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_34/Balance_20240630.xlsx",
+          "company": "Компания 34",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_34/Receivables_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_34/Inventory_2024_05.csv",
+          "company": "Компания 34",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_35/OSV_2023_Q4.xlsx",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_35/PnL_2023_Q4.csv",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_35/Balance_20231231.xlsx",
+          "company": "Компания 35",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_35/Receivables_2023_Q4.xlsx",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_35/Loans_2023_10.txt",
+          "company": "Компания 35",
+          "period": "2023-10",
+          "periodLabel": "Октябрь 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_35/Legal_2023.csv",
+          "company": "Компания 35",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_36/OSV_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_36/PnL_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_36/Balance_20230930.xlsx",
+          "company": "Компания 36",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_36/Receivables_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_36/Inventory_2023_08.csv",
+          "company": "Компания 36",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Дополните справочник подразделений для новых кодов",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_36/Projects_2023.csv",
+          "company": "Компания 36",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Уточните источник данных — файл собран вручную",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_36/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_37/OSV_2024_Q1.xlsx",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_37/PnL_2024_Q1.csv",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_37/Balance_20240331.xlsx",
+          "company": "Компания 37",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_37/Receivables_2024_Q1.xlsx",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_38/OSV_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_38/PnL_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_38/Balance_20240630.xlsx",
+          "company": "Компания 38",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_38/Receivables_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_38/Inventory_2024_05.csv",
+          "company": "Компания 38",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_39/OSV_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_39/PnL_2023_Q4.csv",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_39/Balance_20231231.xlsx",
+          "company": "Компания 39",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_39/Receivables_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_39/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_40/OSV_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_40/PnL_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_40/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_40_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_40/Balance_20230930.xlsx",
+          "company": "Компания 40",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_40/Receivables_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_40/Inventory_2023_08.csv",
+          "company": "Компания 40",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Дополните справочник подразделений для новых кодов"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_40/Projects_2023.csv",
+          "company": "Компания 40",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_40/Legal_2023.csv",
+          "company": "Компания 40",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_41/OSV_2024_Q1.xlsx",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_41/PnL_2024_Q1.csv",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_41/Balance_20240331.xlsx",
+          "company": "Компания 41",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_41/Receivables_2024_Q1.xlsx",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/OSV_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_42/PnL_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/Balance_20240630.xlsx",
+          "company": "Компания 42",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_42/Receivables_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/Inventory_2024_05.csv",
+          "company": "Компания 42",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_42/Loans_2024_04.txt",
+          "company": "Компания 42",
+          "period": "2024-04",
+          "periodLabel": "Апрель 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_42/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_43/OSV_2023_Q4.xlsx",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_43/PnL_2023_Q4.csv",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_43/Balance_20231231.xlsx",
+          "company": "Компания 43",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_43/Receivables_2023_Q4.xlsx",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_44/OSV_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_44/PnL_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_44/Balance_20230930.xlsx",
+          "company": "Компания 44",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_44/Receivables_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_44/Inventory_2023_08.csv",
+          "company": "Компания 44",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_44/Projects_2023.csv",
+          "company": "Компания 44",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_45/OSV_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_45/PnL_2024_Q1.csv",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_45/Balance_20240331.xlsx",
+          "company": "Компания 45",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_45/Receivables_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_45/Legal_2024.csv",
+          "company": "Компания 45",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_45/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_46/OSV_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_46/PnL_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_46/Balance_20240630.xlsx",
+          "company": "Компания 46",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_46/Receivables_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_46/Inventory_2024_05.csv",
+          "company": "Компания 46",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_47/OSV_2023_Q4.xlsx",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_47/PnL_2023_Q4.csv",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_47/Balance_20231231.xlsx",
+          "company": "Компания 47",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_47/Receivables_2023_Q4.xlsx",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/OSV_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_48/PnL_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/Balance_20230930.xlsx",
+          "company": "Компания 48",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_48/Receivables_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/Inventory_2023_08.csv",
+          "company": "Компания 48",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Уточните источник данных — файл собран вручную",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_48/Projects_2023.csv",
+          "company": "Компания 48",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_48/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_49/OSV_2024_Q1.xlsx",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_49/PnL_2024_Q1.csv",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_49/Balance_20240331.xlsx",
+          "company": "Компания 49",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_49/Receivables_2024_Q1.xlsx",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_49/Loans_2024_01.txt",
+          "company": "Компания 49",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Уточните источник данных — файл собран вручную",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Дополните справочник подразделений для новых кодов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_50/OSV_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_50/PnL_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_50/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_50_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_50/Balance_20240630.xlsx",
+          "company": "Компания 50",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_50/Receivables_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_50/Inventory_2024_05.csv",
+          "company": "Компания 50",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_50/Legal_2024.csv",
+          "company": "Компания 50",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_51/OSV_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_51/PnL_2023_Q4.csv",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_51/Balance_20231231.xlsx",
+          "company": "Компания 51",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_51/Receivables_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_51/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_52/OSV_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_52/PnL_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_52/Balance_20230930.xlsx",
+          "company": "Компания 52",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_52/Receivables_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_52/Inventory_2023_08.csv",
+          "company": "Компания 52",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_52/Projects_2023.csv",
+          "company": "Компания 52",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_53/OSV_2024_Q1.xlsx",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_53/PnL_2024_Q1.csv",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_53/Balance_20240331.xlsx",
+          "company": "Компания 53",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_53/Receivables_2024_Q1.xlsx",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/OSV_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_54/PnL_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/Balance_20240630.xlsx",
+          "company": "Компания 54",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_54/Receivables_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/Inventory_2024_05.csv",
+          "company": "Компания 54",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_54/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_55/OSV_2023_Q4.xlsx",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_55/PnL_2023_Q4.csv",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_55/Balance_20231231.xlsx",
+          "company": "Компания 55",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_55/Receivables_2023_Q4.xlsx",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_55/Legal_2023.csv",
+          "company": "Компания 55",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_56/OSV_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_56/PnL_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_56/Balance_20230930.xlsx",
+          "company": "Компания 56",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_56/Receivables_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_56/Inventory_2023_08.csv",
+          "company": "Компания 56",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_56/Projects_2023.csv",
+          "company": "Компания 56",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Дополните справочник подразделений для новых кодов",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_56/Loans_2023_07.txt",
+          "company": "Компания 56",
+          "period": "2023-07",
+          "periodLabel": "Июль 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_57/OSV_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_57/PnL_2024_Q1.csv",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_57/Balance_20240331.xlsx",
+          "company": "Компания 57",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_57/Receivables_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_57/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_58/OSV_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_58/PnL_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_58/Balance_20240630.xlsx",
+          "company": "Компания 58",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_58/Receivables_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_58/Inventory_2024_05.csv",
+          "company": "Компания 58",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_59/OSV_2023_Q4.xlsx",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_59/PnL_2023_Q4.csv",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_59/Balance_20231231.xlsx",
+          "company": "Компания 59",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_59/Receivables_2023_Q4.xlsx",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/OSV_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_60/PnL_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_60_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_60/Balance_20230930.xlsx",
+          "company": "Компания 60",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_60/Receivables_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/Inventory_2023_08.csv",
+          "company": "Компания 60",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_60/Projects_2023.csv",
+          "company": "Компания 60",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_60/Legal_2023.csv",
+          "company": "Компания 60",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_60/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распределила 60 компаний по папкам и ИНН автоматически.",
+          "suggestion": "60 компаний в группе"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По шаблонам заголовков определены ОСВ, ОФР, Баланс, дебиторка, запасы и доп. данные.",
+          "suggestion": "Типы отчётов сопоставлены автоматически"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Дата и период распознаны по 2023–2024 годам, включая месяцы и кварталы.",
+          "suggestion": "Периоды: 2023–2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Компания_10_PnL_2024_Q2",
+          "files": [
+            "Компания_10/PnL_2024_Q2.xlsx",
+            "Компания_10/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 10 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 10, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 10 завершена. Строк объединено: 230."
+          }
+        },
+        {
+          "group": "Компания_20_PnL_2023_Q3",
+          "files": [
+            "Компания_20/PnL_2023_Q3.xlsx",
+            "Компания_20/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 20 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 20, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 20 завершена. Строк объединено: 240."
+          }
+        },
+        {
+          "group": "Компания_30_PnL_2024_Q2",
+          "files": [
+            "Компания_30/PnL_2024_Q2.xlsx",
+            "Компания_30/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 30 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 30, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 30 завершена. Строк объединено: 250."
+          }
+        },
+        {
+          "group": "Компания_40_PnL_2023_Q3",
+          "files": [
+            "Компания_40/PnL_2023_Q3.xlsx",
+            "Компания_40/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 40 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 40, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 40 завершена. Строк объединено: 260."
+          }
+        },
+        {
+          "group": "Компания_50_PnL_2024_Q2",
+          "files": [
+            "Компания_50/PnL_2024_Q2.xlsx",
+            "Компания_50/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 50 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 50, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 50 завершена. Строк объединено: 270."
+          }
+        },
+        {
+          "group": "Компания_60_PnL_2023_Q3",
+          "files": [
+            "Компания_60/PnL_2023_Q3.xlsx",
+            "Компания_60/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 60 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 60, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 60 завершена. Строк объединено: 280."
+          }
+        }
+      ]
+    },
+    {
+      "id": "zipArchive",
+      "label": "ZIP-архив группы",
+      "summary": {
+        "companies": 3,
+        "files": 28,
+        "periods": 5,
+        "formats": [
+          "zip"
+        ],
+        "description": "Архив с вложенными папками компаний"
+      },
+      "recognition": {
+        "recognized": 21,
+        "needsMapping": 4,
+        "duplicates": 3
+      },
+      "files": [
+        {
+          "name": "group_upload.zip/Company_A/OSV_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/PnL_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Balance_31_03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Нужно подтвердить единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Receivables.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/OSV_2024_Q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Mar.xlsx",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Balance_31_03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Inventory_march.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Receivables.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/OSV_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/PnL_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Balance_31_03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Inventory_feb.csv",
+          "company": "Компания C",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Уточнить склад",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Receivables.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/security/events.csv",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/security/partners.xlsx",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/Company_A/cashflow.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/cashflow.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/cashflow.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/readme.txt",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/projects.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "group_upload.zip/Company_B/projects.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "group_upload.zip/Company_C/projects.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "group_upload.zip/security/archive_2023.zip",
+          "company": "Группа",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "zip",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/loans.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Архив содержит подпапки по компаниям.",
+          "suggestion": "Компания А • Компания B • Компания C"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По структуре данных распознаны ОСВ и ОФР.",
+          "suggestion": "Баланс (на дату) и ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Выделен диапазон по именам файлов.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Company_B_PnL",
+          "files": [
+            "group_upload.zip/Company_B/PnL_Jan.xlsx",
+            "group_upload.zip/Company_B/PnL_Feb.xlsx",
+            "group_upload.zip/Company_B/PnL_Mar.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Сохранён последний файл за март, предыдущие помечены как исторические.",
+            "keepOld": "Сохранили январскую версию, остальные спрятаны в архив.",
+            "merge": "Объединение трёх файлов завершено. Строк объединено: 312."
+          }
+        }
+      ]
+    }
+  ],
+  "consolidation": {
+    "baseSummary": {
+      "companies": 60,
+      "files": 331,
+      "period": "2023–2024, смешанные выгрузки",
+      "eliminatedPairs": 28
+    },
+    "totals": {
+      "before": {
+        "revenue": 684000000,
+        "cogs": 512000000,
+        "grossMargin": 172000000,
+        "interestPayable": 12800000,
+        "interestReceivable": 12800000,
+        "intraRevenue": 48000000,
+        "intraCogs": 48000000,
+        "note": "До исключения 60 компаний дают завышенные обороты и проценты"
+      },
+      "after": {
+        "revenue": 636000000,
+        "cogs": 464000000,
+        "grossMargin": 172000000,
+        "interestPayable": 0,
+        "interestReceivable": 0,
+        "note": "Исключения убрали 48 млн внутригрупповой выручки и проценты"
+      }
+    },
+    "eliminationEntries": [
+      {
+        "pair": "Компания 12 → Компания 27",
+        "description": "Поставка оборудования",
+        "amount": 18500000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания 08 ↔ Компания 19",
+        "description": "Совместные услуги",
+        "amount": 12800000,
+        "metric": "Выручка/Прочие расходы"
+      },
+      {
+        "pair": "Компания 33 → Компания 05",
+        "description": "Проценты по внутригрупповому займу",
+        "amount": 6400000,
+        "metric": "Проценты к получению/уплате"
+      },
+      {
+        "pair": "Компания 41 ↔ Компания 52",
+        "description": "Корректировка по остаткам",
+        "amount": 9200000,
+        "metric": "Консервативная корректировка по большей сумме"
+      },
+      {
+        "pair": "Компания 14 → Компания 44",
+        "description": "Передача сырья",
+        "amount": 8700000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания 60 ↔ Компания 11",
+        "description": "Перераспределение лицензий",
+        "amount": 6200000,
+        "metric": "Прочие доходы/расходы"
+      }
+    ],
+    "infoNotes": [
+      "Баланс — на дату. ОФР — за период. Аналогия: камера мгновенной и средней скорости.",
+      "Снятие внутригрупповых оборотов даёт честный результат группы."
+    ],
+    "ruleHints": [
+      "Исключаем проценты к уплате и к получению по внутригрупповым займам.",
+      "Консервативная корректировка: при расхождениях берём большую сумму.",
+      "Правило баланса: нет двойного учёта между дочерними компаниями."
+    ]
+  },
+  "detectors": {
+    "receivables": [
+      {
+        "counterparty": "Торговый дом \"Север\"",
+        "company": "Компания 03",
+        "days": 240,
+        "amount": 7200000,
+        "source": "Receivables_2024_Q1.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Метеор\"",
+        "company": "Компания 18",
+        "days": 305,
+        "amount": 9800000,
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "counterparty": "ЗАО \"Партнёр\"",
+        "company": "Компания 25",
+        "days": 188,
+        "amount": 6100000,
+        "source": "Receivables_2023_Q4.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Орион\"",
+        "company": "Компания 34",
+        "days": 330,
+        "amount": 11200000,
+        "source": "Receivables_2023_Q3.xlsx"
+      },
+      {
+        "counterparty": "ИП Сафронов",
+        "company": "Компания 42",
+        "days": 145,
+        "amount": 4500000,
+        "source": "Receivables_2024_Q1.xlsx"
+      },
+      {
+        "counterparty": "АО \"Логистика\"",
+        "company": "Компания 51",
+        "days": 276,
+        "amount": 8800000,
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Квант\"",
+        "company": "Компания 57",
+        "days": 365,
+        "amount": 12500000,
+        "source": "Receivables_2023_Q4.xlsx"
+      },
+      {
+        "counterparty": "ПАО \"Синтез\"",
+        "company": "Компания 60",
+        "days": 198,
+        "amount": 5400000,
+        "source": "Receivables_2023_Q3.xlsx"
+      }
+    ],
+    "inventory": [
+      {
+        "item": "Партия кабеля КБ-14",
+        "company": "Компания 18",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 2250000,
+        "source": "Inventory_2024_05.csv"
+      },
+      {
+        "item": "Компоненты серии X17",
+        "company": "Компания 12",
+        "issues": [
+          "истёк срок"
+        ],
+        "amount": 1840000,
+        "source": "Inventory_2024_02.csv"
+      },
+      {
+        "item": "Готовая продукция L2",
+        "company": "Компания 25",
+        "issues": [
+          "брак",
+          "долго лежит"
+        ],
+        "amount": 2760000,
+        "source": "Inventory_2023_11.csv"
+      },
+      {
+        "item": "Материалы проекта R",
+        "company": "Компания 33",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 1610000,
+        "source": "Inventory_2023_08.csv"
+      },
+      {
+        "item": "Партия микросхем M9",
+        "company": "Компания 41",
+        "issues": [
+          "брак"
+        ],
+        "amount": 2380000,
+        "source": "Inventory_2024_02.csv"
+      },
+      {
+        "item": "Резервные модули S3",
+        "company": "Компания 54",
+        "issues": [
+          "долго лежит",
+          "истёк срок"
+        ],
+        "amount": 3120000,
+        "source": "Inventory_2023_11.csv"
+      }
+    ],
+    "legend": {
+      "receivables": "Дебиторка",
+      "inventory": "Запасы"
+    }
+  },
+  "liquidation": {
+    "before": {
+      "equity": 182000000,
+      "cash": 48500000,
+      "assets": [
+        {
+          "label": "Дебиторская задолженность",
+          "amount": 84500000
+        },
+        {
+          "label": "Запасы",
+          "amount": 67400000
+        },
+        {
+          "label": "Основные средства",
+          "amount": 123500000
+        },
+        {
+          "label": "Прочие активы",
+          "amount": 28500000
+        }
+      ]
+    },
+    "adjustments": [
+      {
+        "label": "Списание дебитора ООО \"Метеор\"",
+        "impact": -9800000,
+        "reason": ">300 дней без оплаты",
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "label": "Списание партии КБ-14",
+        "impact": -2250000,
+        "reason": "неликвид > 10 месяцев",
+        "source": "Inventory_2024_05.csv"
+      },
+      {
+        "label": "Дисконт готовой продукции L2",
+        "impact": -1620000,
+        "reason": "брак и переоценка",
+        "source": "Inventory_2023_11.csv"
+      },
+      {
+        "label": "Резерв по проектам высокого риска",
+        "impact": -5400000,
+        "reason": "пересмотр денежных потоков",
+        "source": "Projects_2024.csv"
+      }
+    ],
+    "after": {
+      "equity": 132000000,
+      "cash": 62500000,
+      "ownerStatement": "Оценка: после очистки собственник может рассчитывать на ~62,5 млн руб. живыми деньгами."
+    }
+  },
+  "trafficLight": {
+    "statusLabels": {
+      "all": "Все",
+      "green": "Зелёные",
+      "yellow": "Жёлтые",
+      "red": "Красные"
+    },
+    "items": [
+      {
+        "name": "ООО \"Форвард\"",
+        "company": "Компания 03",
+        "status": "green",
+        "financial": "Платёж дисциплинирован, оборачиваемость 32 дня.",
+        "legal": "Нет активных судебных дел.",
+        "note": "Допустимый лимит 18 млн руб."
+      },
+      {
+        "name": "АО \"Логистика\"",
+        "company": "Компания 18",
+        "status": "yellow",
+        "financial": "Просрочка выросла до 60 дней.",
+        "legal": "Исполнительное производство на 4,2 млн руб.",
+        "note": "Рекомендация: ужесточить условия поставок."
+      },
+      {
+        "name": "ООО \"Метеор\"",
+        "company": "Компания 18",
+        "status": "red",
+        "financial": "Просрочка 305 дней, резкое падение оборотов.",
+        "legal": "Получено уведомление о подготовке к банкротству.",
+        "note": "Поставки остановлены, контроль службы безопасности."
+      },
+      {
+        "name": "ЗАО \"Партнёр\"",
+        "company": "Компания 25",
+        "status": "yellow",
+        "financial": "Просрочка 188 дней, есть частичные оплаты.",
+        "legal": "Претензионная работа без суда.",
+        "note": "Рекомендуем переход на предоплату."
+      },
+      {
+        "name": "ИП Сафронов",
+        "company": "Компания 42",
+        "status": "green",
+        "financial": "Оплата вовремя, обороты растут.",
+        "legal": "Нарушений нет.",
+        "note": "Можно расширить лимит до 7 млн руб."
+      },
+      {
+        "name": "ПАО \"Синтез\"",
+        "company": "Компания 60",
+        "status": "yellow",
+        "financial": "Промедление платежей до 50 дней.",
+        "legal": "Появилась судебная претензия контрагента.",
+        "note": "Контроль менеджмента, запрос финансовой отчётности."
+      },
+      {
+        "name": "ООО \"Квант\"",
+        "company": "Компания 57",
+        "status": "red",
+        "financial": "Просрочка 365 дней, высокая долговая нагрузка.",
+        "legal": "Инициирована процедура наблюдения.",
+        "note": "Договор расторгнут, требуется работа с обеспечением."
+      },
+      {
+        "name": "АО \"Регионстрой\"",
+        "company": "Компания 21",
+        "status": "green",
+        "financial": "Стабильные платежи, маржа 18%.",
+        "legal": "Нет негативных событий.",
+        "note": "Расширяем лимит до 22 млн руб."
+      }
+    ]
+  },
+  "finalSummary": {
+    "headline": "Минуты вместо дней. Минимум ручного труда. Комплекс отчётов готов.",
+    "points": [
+      "Файлы собраны, нормализованы и сведены в одну базу.",
+      "Проблемные зоны подсвечены автоматически.",
+      "Команда видит, где действовать первой."
+    ],
+    "disclaimer": "Демонстрационный прототип. Данные и расчёты упрощены."
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,1957 @@
+const state = {
+  config: null,
+  data: null,
+  currentScenario: null,
+  mappingComplete: false,
+  duplicateDecisions: new Map(),
+  lastDuplicateBulkAction: null,
+  flaggedReceivables: new Set(),
+  threshold: null,
+  inventoryFilters: new Set(),
+  liquidationCleaned: false,
+  trafficFilter: 'all',
+  trafficCompany: 'all',
+  progressStart: 0,
+  progressDuration: 0,
+  progressFrame: null,
+  lastUploadCount: 0,
+  virtualRenderTokens: {},
+  showAdjustedMetrics: true,
+  activeDetector: 'receivables'
+};
+
+const elements = {};
+
+const numberFormatter = new Intl.NumberFormat('ru-RU');
+const FILE_BATCH_SIZE = 16;
+const THEME_STORAGE_KEY = 'solward-theme';
+const DUPLICATE_ACTIONS = [
+  { action: 'keepOld', label: 'Оставить старый', status: 'Выбран старый файл' },
+  { action: 'keepNew', label: 'Оставить новый', status: 'Выбран новый файл' },
+  { action: 'merge', label: 'Склеить', status: 'Файлы будут объединены' }
+];
+
+const DUPLICATE_BULK_OPTIONS = [
+  {
+    action: 'keepNew',
+    label: 'Использовать новые файлы',
+    description: 'Заменить предыдущие выгрузки последними версиями и продолжить консолидацию.'
+  },
+  {
+    action: 'keepOld',
+    label: 'Использовать старые файлы',
+    description: 'Сохранить исходные данные и исключить загруженные дубликаты из обработки.'
+  },
+  {
+    action: 'merge',
+    label: 'Объединить дубликаты',
+    description: 'Склеить совпадающие строки и сформировать единый набор данных по каждой компании.'
+  },
+  {
+    action: 'manual',
+    label: 'Просмотреть все файлы вручную',
+    description: 'Перейти к вкладке «Дубликаты» и принять решения по каждой группе самостоятельно.'
+  }
+];
+
+document.addEventListener('DOMContentLoaded', init);
+
+async function init() {
+  cacheElements();
+  initializeTheme();
+  setUploadActionsVisibility(false);
+  setDemoScenarioAvailability(false);
+  const resources = await loadResources();
+  if (!resources) {
+    displayResourceLoadError();
+    return;
+  }
+
+  state.config = resources.config;
+  state.data = resources.data;
+
+  setupEventHandlers();
+  initializeProgressSteps();
+  initializeInventoryFilters();
+  initializeTrafficFilters();
+  initializeTrafficCompanies();
+  renderFinalScreen();
+  updateCTA();
+  renderTrafficList();
+
+  setDemoScenarioAvailability(true);
+}
+
+function cacheElements() {
+  elements.dropZone = document.getElementById('dropZone');
+  elements.fileInput = document.getElementById('fileInput');
+  elements.demoScenario = document.getElementById('demoScenario');
+  elements.themeToggle = document.getElementById('themeToggle');
+  elements.summaryFiles = document.getElementById('summary-files');
+  elements.summaryCompanies = document.getElementById('summary-companies');
+  elements.summaryPeriods = document.getElementById('summary-periods');
+  elements.summaryFormats = document.getElementById('summary-formats');
+  elements.summaryDescription = document.getElementById('summary-description');
+  elements.summaryPeriodsDetail = document.getElementById('summary-periods-detail');
+  elements.recognitionLegend = document.getElementById('recognition-legend');
+  elements.badgeFiles = document.getElementById('badge-files');
+  elements.badgeCompanies = document.getElementById('badge-companies');
+  elements.badgePeriods = document.getElementById('badge-periods');
+  elements.badgeFormats = document.getElementById('badge-formats');
+  elements.tabAttention = document.getElementById('tab-attention');
+  elements.tabDuplicates = document.getElementById('tab-duplicates');
+  elements.tabCatalog = document.getElementById('tab-catalog');
+  elements.panelAttention = document.getElementById('panel-attention');
+  elements.panelDuplicates = document.getElementById('panel-duplicates');
+  elements.panelCatalog = document.getElementById('panel-catalog');
+  elements.companyFileList = document.getElementById('companyFileList');
+  elements.periodFileList = document.getElementById('periodFileList');
+  elements.tabCompanies = document.getElementById('tab-companies');
+  elements.tabPeriods = document.getElementById('tab-periods');
+  elements.panelCompanies = document.getElementById('panel-companies');
+  elements.panelPeriods = document.getElementById('panel-periods');
+  elements.attentionList = document.getElementById('attentionList');
+  elements.duplicateList = document.getElementById('duplicateList');
+  elements.startMapping = document.getElementById('startMapping');
+  elements.startConsolidation = document.getElementById('startConsolidation');
+  elements.uploadScreen = document.getElementById('upload-screen');
+  elements.progressScreen = document.getElementById('progress-screen');
+  elements.triadScreen = document.getElementById('triad-screen');
+  elements.progressIndicator = document.getElementById('progressIndicator');
+  elements.progressValue = document.getElementById('progressValue');
+  elements.progressSteps = document.getElementById('progressSteps');
+  elements.progressStatus = document.getElementById('progressStatus');
+  elements.triadNavButtons = document.querySelectorAll('.triad-nav-btn');
+  elements.consolidationMetrics = document.getElementById('consolidationMetrics');
+  elements.toggleAdjustments = document.getElementById('toggleAdjustments');
+  elements.showEliminations = document.getElementById('showEliminations');
+  elements.eliminationDetails = document.getElementById('eliminationDetails');
+  elements.consolidationHints = document.getElementById('consolidationHints');
+  elements.consolidationRules = document.getElementById('consolidationRules');
+  elements.thresholdRange = document.getElementById('thresholdRange');
+  elements.thresholdValue = document.getElementById('thresholdValue');
+  elements.receivablesList = document.getElementById('receivablesList');
+  elements.sendToTraffic = document.getElementById('sendToTraffic');
+  elements.trafficMessage = document.getElementById('trafficMessage');
+  elements.inventoryFilters = document.getElementById('inventoryFilters');
+  elements.inventoryList = document.getElementById('inventoryList');
+  elements.detectorTabButtons = Array.from(document.querySelectorAll('.detector-tab-btn'));
+  elements.detectorReceivables = document.getElementById('detector-receivables');
+  elements.detectorInventory = document.getElementById('detector-inventory');
+  elements.cleanBalance = document.getElementById('cleanBalance');
+  elements.liquidationBeforeSummary = document.getElementById('liquidationBeforeSummary');
+  elements.liquidationAssets = document.getElementById('liquidationAssets');
+  elements.liquidationAdjustments = document.getElementById('liquidationAdjustments');
+  elements.liquidationAfterSummary = document.getElementById('liquidationAfterSummary');
+  elements.ownerStatement = document.getElementById('ownerStatement');
+  elements.trafficFilters = document.getElementById('trafficFilters');
+  elements.trafficCompany = document.getElementById('trafficCompany');
+  elements.trafficList = document.getElementById('trafficList');
+  elements.finalHeadline = document.getElementById('finalHeadline');
+  elements.finalPoints = document.getElementById('finalPoints');
+  elements.finalDisclaimer = document.getElementById('finalDisclaimer');
+  elements.ctaButton = document.getElementById('ctaButton');
+  elements.mappingTemplate = document.getElementById('mappingStepTemplate');
+  elements.duplicateBulkTemplate = document.getElementById('duplicateBulkTemplate');
+  elements.uploadActions = document.querySelector('.upload-actions');
+}
+
+function initializeTheme() {
+  const storedTheme = getStoredTheme();
+  const prefersLight =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: light)').matches
+      : false;
+  const theme = storedTheme || (prefersLight ? 'light' : 'dark');
+  applyTheme(theme);
+}
+
+function getStoredTheme() {
+  try {
+    return localStorage.getItem(THEME_STORAGE_KEY);
+  } catch (error) {
+    return null;
+  }
+}
+
+function persistTheme(theme) {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    // ignore storage errors
+  }
+}
+
+function applyTheme(theme) {
+  const nextTheme = theme === 'light' ? 'light' : 'dark';
+  document.body.dataset.theme = nextTheme;
+  updateThemeToggle(nextTheme);
+  persistTheme(nextTheme);
+}
+
+function toggleTheme() {
+  const currentTheme = document.body.dataset.theme === 'light' ? 'light' : 'dark';
+  const nextTheme = currentTheme === 'light' ? 'dark' : 'light';
+  applyTheme(nextTheme);
+}
+
+function updateThemeToggle(theme) {
+  if (!elements.themeToggle) {
+    return;
+  }
+  const isLight = theme === 'light';
+  elements.themeToggle.setAttribute('aria-pressed', String(isLight));
+  const actionLabel = isLight ? 'Переключить на тёмную тему' : 'Переключить на светлую тему';
+  elements.themeToggle.setAttribute('aria-label', actionLabel);
+  elements.themeToggle.setAttribute('title', actionLabel);
+  const icon = elements.themeToggle.querySelector('.theme-toggle__icon');
+  const label = elements.themeToggle.querySelector('.theme-toggle__label');
+  if (icon) {
+    icon.textContent = isLight ? '🌞' : '🌙';
+  }
+  if (label) {
+    label.textContent = isLight ? 'Тёмная тема' : 'Светлая тема';
+  }
+}
+
+function setDemoScenarioAvailability(enabled) {
+  if (!elements.demoScenario) {
+    return;
+  }
+  elements.demoScenario.disabled = !enabled;
+  if (enabled) {
+    elements.demoScenario.removeAttribute('aria-disabled');
+  } else {
+    elements.demoScenario.setAttribute('aria-disabled', 'true');
+  }
+}
+
+function setupEventHandlers() {
+  elements.dropZone.addEventListener('dragover', onDragOver);
+  elements.dropZone.addEventListener('dragleave', onDragLeave);
+  elements.dropZone.addEventListener('drop', onDropFiles);
+  elements.dropZone.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      elements.fileInput.click();
+    }
+  });
+
+  elements.fileInput.addEventListener('change', (event) => {
+    handleFiles(event.target.files);
+  });
+
+  if (elements.themeToggle) {
+    elements.themeToggle.addEventListener('click', toggleTheme);
+  }
+
+  elements.demoScenario.addEventListener('click', () => {
+    if (!state.data?.uploadScenarios?.length) {
+      return;
+    }
+    const scenario = state.data.uploadScenarios[1] || state.data.uploadScenarios[0];
+    loadScenario(scenario, scenario.summary.files);
+  });
+
+  const mainTabs = [elements.tabAttention, elements.tabDuplicates, elements.tabCatalog];
+  const mainTabHandler = createTabKeydownHandler(mainTabs);
+  const groupingTabs = [elements.tabCompanies, elements.tabPeriods];
+  const groupingTabHandler = createTabKeydownHandler(groupingTabs);
+  const detectorTabs = elements.detectorTabButtons || [];
+  const detectorTabHandler = createTabKeydownHandler(detectorTabs);
+
+  if (elements.tabAttention) {
+    elements.tabAttention.addEventListener('click', () => setActiveMainTab('attention'));
+    elements.tabAttention.addEventListener('keydown', mainTabHandler);
+  }
+  if (elements.tabDuplicates) {
+    elements.tabDuplicates.addEventListener('click', () => setActiveMainTab('duplicates'));
+    elements.tabDuplicates.addEventListener('keydown', mainTabHandler);
+  }
+  if (elements.tabCatalog) {
+    elements.tabCatalog.addEventListener('click', () => setActiveMainTab('catalog'));
+    elements.tabCatalog.addEventListener('keydown', mainTabHandler);
+  }
+
+  elements.tabCompanies.addEventListener('click', () => setActiveTab('companies'));
+  elements.tabPeriods.addEventListener('click', () => setActiveTab('periods'));
+  groupingTabs.forEach((tab) => {
+    if (tab) {
+      tab.addEventListener('keydown', groupingTabHandler);
+    }
+  });
+
+  detectorTabs.forEach((button) => {
+    if (!button) {
+      return;
+    }
+    button.addEventListener('click', () => switchDetectorPanel(button.dataset.detector, button));
+    button.addEventListener('keydown', detectorTabHandler);
+  });
+
+  elements.startMapping.addEventListener('click', handleMappingButtonClick);
+  elements.startConsolidation.addEventListener('click', startConsolidation);
+
+  elements.triadNavButtons.forEach((button) => {
+    button.addEventListener('click', () => switchTriadPanel(button.dataset.target, button));
+  });
+
+  if (elements.toggleAdjustments) {
+    elements.toggleAdjustments.addEventListener('click', toggleAdjustmentMode);
+  }
+  elements.showEliminations.addEventListener('click', toggleEliminationList);
+
+  elements.thresholdRange.min = state.config.receivables.minDays;
+  elements.thresholdRange.max = state.config.receivables.maxDays;
+  elements.thresholdRange.addEventListener('input', (event) => {
+    state.threshold = Number(event.target.value);
+    elements.thresholdValue.textContent = state.threshold;
+    renderReceivables();
+  });
+
+  elements.sendToTraffic.addEventListener('click', addReceivablesToTraffic);
+
+  elements.cleanBalance.addEventListener('click', applyLiquidationScenario);
+  elements.trafficCompany.addEventListener('change', (event) => {
+    state.trafficCompany = event.target.value;
+    renderTrafficList();
+  });
+}
+
+function onDragOver(event) {
+  event.preventDefault();
+  elements.dropZone.classList.add('dragover');
+}
+
+function onDragLeave(event) {
+  event.preventDefault();
+  elements.dropZone.classList.remove('dragover');
+}
+
+function onDropFiles(event) {
+  event.preventDefault();
+  elements.dropZone.classList.remove('dragover');
+  const files = event.dataTransfer?.files;
+  if (files && files.length) {
+    handleFiles(files);
+  }
+}
+
+function handleFiles(fileList) {
+  state.lastUploadCount = fileList.length;
+  const scenario = chooseScenario(Array.from(fileList));
+  loadScenario(scenario, fileList.length);
+  elements.fileInput.value = '';
+}
+
+function chooseScenario(files) {
+  if (!files || !files.length) {
+    return state.data.uploadScenarios[0];
+  }
+  const hasZip = files.some((file) => file.name.toLowerCase().endsWith('.zip'));
+  if (hasZip) {
+    return state.data.uploadScenarios.find((item) => item.id === 'zipArchive') || state.data.uploadScenarios[0];
+  }
+  if (files.length > 20) {
+    return state.data.uploadScenarios.find((item) => item.id === 'groupUpload') || state.data.uploadScenarios[0];
+  }
+  return state.data.uploadScenarios.find((item) => item.id === 'singleCompany') || state.data.uploadScenarios[0];
+}
+
+function loadScenario(scenario, uploadedCount = 0) {
+  if (!scenario) {
+    return;
+  }
+  state.currentScenario = scenario;
+  state.mappingComplete = scenario.mappingSteps?.length === 0;
+  state.duplicateDecisions = new Map();
+  state.lastDuplicateBulkAction = null;
+  state.showAdjustedMetrics = true;
+  state.flaggedReceivables.clear();
+  state.inventoryFilters.clear();
+  state.liquidationCleaned = false;
+  state.threshold = state.config.receivables.defaultThreshold;
+  state.activeDetector = 'receivables';
+  elements.thresholdRange.value = state.threshold;
+  elements.thresholdValue.textContent = state.threshold;
+  state.lastUploadCount = uploadedCount;
+  elements.trafficMessage.textContent = '';
+  setUploadActionsVisibility(true);
+  showDuplicatePanel();
+
+  elements.inventoryFilters.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+    checkbox.checked = false;
+  });
+
+  renderScenarioSummary();
+  renderGroupings();
+  renderAttentionList();
+  renderDuplicateList();
+  setActiveMainTab('attention');
+  setActiveTab('companies');
+  updateMappingButton();
+  updateStartButtonState();
+  resetScreensToUpload();
+  elements.triadNavButtons.forEach((btn, idx) => {
+    btn.setAttribute('aria-pressed', idx === 0 ? 'true' : 'false');
+  });
+  elements.eliminationDetails.setAttribute('hidden', '');
+  elements.showEliminations.textContent = 'Показать снятые внутригрупповые обороты';
+  elements.showEliminations.setAttribute('aria-expanded', 'false');
+  resetLiquidationView();
+  state.trafficFilter = 'all';
+  state.trafficCompany = 'all';
+  elements.trafficFilters.querySelectorAll('button').forEach((btn) => {
+    const active = btn.dataset.value === 'all';
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  elements.trafficCompany.value = 'all';
+  renderReceivables();
+  renderInventoryList();
+  renderTrafficList();
+}
+
+function setUploadActionsVisibility(visible) {
+  if (!elements.uploadActions) {
+    return;
+  }
+  if (visible) {
+    elements.uploadActions.removeAttribute('hidden');
+  } else {
+    elements.uploadActions.setAttribute('hidden', '');
+  }
+}
+
+function renderScenarioSummary() {
+  const scenario = state.currentScenario;
+  elements.summaryFiles.textContent = scenario.summary.files;
+  elements.summaryCompanies.textContent = scenario.summary.companies;
+  elements.summaryPeriods.textContent = scenario.summary.periods;
+  elements.summaryFormats.textContent = scenario.summary.formats.join(' • ');
+  const uploadInfo = state.lastUploadCount ? `Загружено: ${state.lastUploadCount}` : 'Готовый демо-набор';
+  elements.summaryDescription.textContent = `${uploadInfo}. Сценарий: ${scenario.summary.description}.`;
+  const periodLabels = Array.from(
+    new Set(
+      scenario.files
+        .map((file) => file.periodLabel || file.period)
+        .filter((value) => Boolean(value))
+    )
+  );
+  if (periodLabels.length) {
+    const preview = periodLabels.slice(0, 3).join(' • ');
+    const remainder = periodLabels.length > 3 ? ` и ещё ${periodLabels.length - 3}` : '';
+    elements.summaryPeriodsDetail.textContent = `${preview}${remainder}`;
+    elements.badgePeriods.setAttribute('title', periodLabels.join(', '));
+  } else {
+    elements.summaryPeriodsDetail.textContent = 'Периоды появятся после загрузки';
+    elements.badgePeriods.removeAttribute('title');
+  }
+  elements.recognitionLegend.textContent = `Распознано: ${scenario.recognition.recognized} • Требует сверки: ${scenario.recognition.needsMapping} • Дубликаты: ${scenario.recognition.duplicates}`;
+  elements.badgeFiles.textContent = `Файлов: ${scenario.summary.files}`;
+  elements.badgeCompanies.textContent = `Компаний: ${scenario.summary.companies}`;
+  elements.badgePeriods.textContent = `Периодов: ${scenario.summary.periods}`;
+  elements.badgeFormats.textContent = `Форматы: ${scenario.summary.formats.join(', ')}`;
+}
+
+function renderGroupings() {
+  const scenario = state.currentScenario;
+  renderCompanyGroups(scenario.files);
+  renderPeriodGroups(scenario.files);
+}
+
+function createRenderToken(key) {
+  if (!state.virtualRenderTokens) {
+    state.virtualRenderTokens = {};
+  }
+  if (state.virtualRenderTokens[key]) {
+    state.virtualRenderTokens[key].cancelled = true;
+  }
+  const token = { cancelled: false };
+  state.virtualRenderTokens[key] = token;
+  return token;
+}
+
+function finalizeRenderToken(key, token) {
+  if (state.virtualRenderTokens[key] === token) {
+    state.virtualRenderTokens[key] = null;
+  }
+}
+
+function renderCompanyGroups(files) {
+  const token = createRenderToken('companies');
+  elements.companyFileList.innerHTML = '';
+  if (!files.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Нет файлов для отображения.';
+    elements.companyFileList.appendChild(message);
+    elements.companyFileList.removeAttribute('aria-busy');
+    finalizeRenderToken('companies', token);
+    return;
+  }
+
+  elements.companyFileList.setAttribute('aria-busy', 'true');
+  const companyMap = new Map();
+  files.forEach((file) => {
+    if (!companyMap.has(file.company)) {
+      companyMap.set(file.company, []);
+    }
+    companyMap.get(file.company).push(file);
+  });
+  const entries = Array.from(companyMap.entries());
+  let index = 0;
+
+  const renderNextGroup = () => {
+    if (token.cancelled) {
+      return;
+    }
+    if (index >= entries.length) {
+      if (!token.cancelled) {
+        elements.companyFileList.removeAttribute('aria-busy');
+        finalizeRenderToken('companies', token);
+      }
+      return;
+    }
+
+    const [company, companyFiles] = entries[index];
+    const details = document.createElement('details');
+    details.className = 'file-group';
+    details.open = entries.length <= 4;
+    const summary = document.createElement('summary');
+    summary.textContent = `${company} • ${companyFiles.length} файлов`;
+    details.appendChild(summary);
+    const body = document.createElement('div');
+    body.className = 'file-group__body';
+    details.appendChild(body);
+    elements.companyFileList.appendChild(details);
+
+    let fileIndex = 0;
+
+    const renderFileBatch = () => {
+      if (token.cancelled) {
+        return;
+      }
+      const fragment = document.createDocumentFragment();
+      let batchCount = 0;
+      while (fileIndex < companyFiles.length && batchCount < FILE_BATCH_SIZE) {
+        fragment.appendChild(createFileRow(companyFiles[fileIndex]));
+        fileIndex += 1;
+        batchCount += 1;
+      }
+      body.appendChild(fragment);
+      if (fileIndex < companyFiles.length) {
+        requestAnimationFrame(renderFileBatch);
+      } else {
+        index += 1;
+        requestAnimationFrame(renderNextGroup);
+      }
+    };
+
+    requestAnimationFrame(renderFileBatch);
+  };
+
+  requestAnimationFrame(renderNextGroup);
+}
+
+function renderPeriodGroups(files) {
+  const token = createRenderToken('periods');
+  elements.periodFileList.innerHTML = '';
+  if (!files.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Нет файлов для отображения.';
+    elements.periodFileList.appendChild(message);
+    elements.periodFileList.removeAttribute('aria-busy');
+    finalizeRenderToken('periods', token);
+    return;
+  }
+
+  elements.periodFileList.setAttribute('aria-busy', 'true');
+  const yearMap = new Map();
+  files.forEach((file) => {
+    const year = file.period?.toString().slice(0, 4) || 'Не указан';
+    if (!yearMap.has(year)) {
+      yearMap.set(year, new Map());
+    }
+    const periodKey = file.periodLabel || file.period || 'Без периода';
+    const periodMap = yearMap.get(year);
+    if (!periodMap.has(periodKey)) {
+      periodMap.set(periodKey, []);
+    }
+    periodMap.get(periodKey).push(file);
+  });
+
+  const yearEntries = Array.from(yearMap.entries());
+  let yearIndex = 0;
+
+  const renderNextYear = () => {
+    if (token.cancelled) {
+      return;
+    }
+    if (yearIndex >= yearEntries.length) {
+      if (!token.cancelled) {
+        elements.periodFileList.removeAttribute('aria-busy');
+        finalizeRenderToken('periods', token);
+      }
+      return;
+    }
+
+    const [year, periodMap] = yearEntries[yearIndex];
+    const details = document.createElement('details');
+    details.className = 'file-group';
+    details.open = yearEntries.length <= 3;
+    const totalFiles = Array.from(periodMap.values()).reduce((acc, list) => acc + list.length, 0);
+    const summary = document.createElement('summary');
+    summary.textContent = `${year} • ${totalFiles} файлов`;
+    details.appendChild(summary);
+    const body = document.createElement('div');
+    body.className = 'file-group__body period-grid';
+    details.appendChild(body);
+    elements.periodFileList.appendChild(details);
+
+    const periods = Array.from(periodMap.entries());
+    let periodIndex = 0;
+
+    const renderPeriodBatch = () => {
+      if (token.cancelled) {
+        return;
+      }
+      const fragment = document.createDocumentFragment();
+      let batchCount = 0;
+      while (periodIndex < periods.length && batchCount < FILE_BATCH_SIZE) {
+        const [periodLabel, periodFiles] = periods[periodIndex];
+        const card = document.createElement('article');
+        card.className = 'period-card';
+        const header = document.createElement('div');
+        header.className = 'period-card__header';
+        const title = document.createElement('h4');
+        title.textContent = periodLabel;
+        const count = document.createElement('span');
+        count.className = 'section-subtitle';
+        count.textContent = `${periodFiles.length} файлов`;
+        header.appendChild(title);
+        header.appendChild(count);
+        card.appendChild(header);
+        const list = document.createElement('div');
+        list.className = 'period-card__list';
+        periodFiles.forEach((file) => {
+          list.appendChild(createFileRow(file, { compact: true }));
+        });
+        card.appendChild(list);
+        fragment.appendChild(card);
+        periodIndex += 1;
+        batchCount += 1;
+      }
+
+      body.appendChild(fragment);
+
+      if (periodIndex < periods.length) {
+        requestAnimationFrame(renderPeriodBatch);
+      } else {
+        yearIndex += 1;
+        requestAnimationFrame(renderNextYear);
+      }
+    };
+
+    requestAnimationFrame(renderPeriodBatch);
+  };
+
+  requestAnimationFrame(renderNextYear);
+}
+
+function createSeededGenerator(seedSource) {
+  let hash = 0;
+  const source = String(seedSource || '');
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash << 5) - hash + source.charCodeAt(i);
+    hash |= 0;
+  }
+
+  if (hash === 0) {
+    hash = 123456789;
+  }
+
+  return () => {
+    hash = (hash * 1664525 + 1013904223) % 4294967296;
+    return (hash >>> 0) / 4294967296;
+  };
+}
+
+function sampleHints(hints, options = {}) {
+  const uniqueHints = [...new Set(hints.filter(Boolean))];
+
+  if (!uniqueHints.length) {
+    return uniqueHints;
+  }
+
+  const summaryIndex = uniqueHints.findIndex((hint) => hint.startsWith('Всего:'));
+  const summaryHint = summaryIndex >= 0 ? uniqueHints.splice(summaryIndex, 1)[0] : null;
+
+  const seededRandom = createSeededGenerator(options.seed);
+  const maxAdditional = Math.min(uniqueHints.length, 4);
+  const minAdditional = summaryHint ? 0 : Math.min(1, maxAdditional);
+  const range = maxAdditional - minAdditional + 1;
+  const additionalCount = range > 0 ? minAdditional + Math.floor(seededRandom() * range) : 0;
+
+  for (let i = uniqueHints.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(seededRandom() * (i + 1));
+    [uniqueHints[i], uniqueHints[j]] = [uniqueHints[j], uniqueHints[i]];
+  }
+
+  const selected = summaryHint ? [summaryHint] : [];
+  for (let i = 0; i < additionalCount; i += 1) {
+    selected.push(uniqueHints[i]);
+  }
+
+  return selected;
+}
+
+function collectMappingHints(file, options) {
+  if (!file || options?.showHint === false) {
+    return [];
+  }
+
+  const hints = [];
+
+  if (Array.isArray(file.mappingHints)) {
+    hints.push(...file.mappingHints.filter(Boolean));
+  } else if (file.mappingHint) {
+    hints.push(file.mappingHint);
+  }
+
+  if (file.attentionSummary) {
+    hints.push(file.attentionSummary);
+  }
+
+  if (file.status === 'mapping') {
+    const type = (file.type || '').toLowerCase();
+    switch (type) {
+      case 'запасы':
+        hints.push(
+          'Сверьте склад и подразделение: часть строк пришла из архивных выгрузок',
+          'Проверьте сроки годности и отметку неликвида перед загрузкой'
+        );
+        break;
+      case 'дебиторка':
+        hints.push(
+          'Подтвердите валюту и курс пересчёта — файл содержит несколько валют',
+          'Сопоставьте ИНН и договор, чтобы исключить задвоение контрагентов'
+        );
+        break;
+      case 'прочее':
+        hints.push(
+          'Определите назначение файла: бухгалтерия пометила его как «Прочее»',
+          'Уточните период отчётности — название содержит только квартал'
+        );
+        break;
+      default:
+        break;
+    }
+
+    if ((file.format || '').toLowerCase() === 'csv') {
+      hints.push('Проверьте разделитель и кодировку — файл загружен в формате CSV');
+    }
+  }
+
+  return sampleHints(hints, { seed: `${file.company || ''}-${file.period || ''}-${file.name || ''}` });
+}
+
+function createFileRow(file, options = {}) {
+  const hints = collectMappingHints(file, options);
+
+  if (options.compact) {
+    const row = document.createElement('div');
+    row.className = 'file-row file-row--compact';
+
+    const name = document.createElement('span');
+    name.textContent = file.name;
+    row.appendChild(name);
+
+    const type = document.createElement('span');
+    type.className = 'file-tag file-tag--type';
+    type.textContent = file.format ? `${file.type} (${file.format})` : file.type;
+    row.appendChild(type);
+
+    const period = document.createElement('span');
+    period.className = 'file-tag file-tag--period';
+    period.textContent = file.periodLabel || file.period || '—';
+    row.appendChild(period);
+
+    const origin = document.createElement('span');
+    origin.className = 'file-tag file-tag--origin';
+    origin.textContent = file.origin || '—';
+    row.appendChild(origin);
+
+    const status = document.createElement('span');
+    status.className = 'file-status';
+    status.dataset.status = file.status || 'recognized';
+    status.textContent = statusLabel(file.status);
+    row.appendChild(status);
+
+    if (hints.length) {
+      const hint = document.createElement('span');
+      hint.textContent = hints.join(' • ');
+      hint.className = 'section-subtitle';
+      hint.style.gridColumn = '1 / -1';
+      row.appendChild(hint);
+    }
+
+    if (options.actions) {
+      const actionsContainer = document.createElement('div');
+      actionsContainer.className = 'file-actions';
+      actionsContainer.style.gridColumn = '1 / -1';
+      options.actions.forEach((actionButton) => {
+        actionsContainer.appendChild(actionButton);
+      });
+      row.appendChild(actionsContainer);
+    }
+
+    return row;
+  }
+
+  const hasExpandableContent = Boolean(hints.length || options.actions);
+
+  const container = document.createElement(hasExpandableContent ? 'details' : 'article');
+  container.className = 'file-card';
+  if (hasExpandableContent) {
+    container.classList.add('file-card--expandable');
+  }
+
+  const buildSummary = (summaryElement) => {
+    summaryElement.className = 'file-card__summary';
+    if (!hasExpandableContent) {
+      summaryElement.classList.add('file-card__summary--static');
+    }
+
+    const top = document.createElement('div');
+    top.className = 'file-card__top';
+
+    const title = document.createElement('span');
+    title.className = 'file-card__name';
+    title.textContent = file.name;
+    top.appendChild(title);
+
+    const status = document.createElement('span');
+    status.className = 'file-status';
+    status.dataset.status = file.status || 'recognized';
+    status.textContent = statusLabel(file.status);
+    top.appendChild(status);
+
+    if (hasExpandableContent) {
+      top.classList.add('file-card__top--expandable');
+      const caret = document.createElement('span');
+      caret.className = 'file-card__caret';
+      caret.setAttribute('aria-hidden', 'true');
+      top.appendChild(caret);
+    }
+
+    summaryElement.appendChild(top);
+
+    const tagList = document.createElement('div');
+    tagList.className = 'file-card__tags';
+
+    const type = document.createElement('span');
+    type.className = 'file-tag file-tag--type';
+    type.textContent = file.format ? `${file.type} (${file.format})` : file.type;
+    tagList.appendChild(type);
+
+    const period = document.createElement('span');
+    period.className = 'file-tag file-tag--period';
+    period.textContent = file.periodLabel || file.period || '—';
+    tagList.appendChild(period);
+
+    const origin = document.createElement('span');
+    origin.className = 'file-tag file-tag--origin';
+    origin.textContent = file.origin || '—';
+    tagList.appendChild(origin);
+
+    summaryElement.appendChild(tagList);
+
+    return summaryElement;
+  };
+
+  if (hasExpandableContent) {
+    const summary = document.createElement('summary');
+    buildSummary(summary);
+    container.appendChild(summary);
+  } else {
+    const summary = document.createElement('div');
+    buildSummary(summary);
+    container.appendChild(summary);
+  }
+
+  if (hasExpandableContent) {
+    const body = document.createElement('div');
+    body.className = 'file-card__body';
+
+    if (hints.length) {
+      const hintList = document.createElement('div');
+      hintList.className = 'file-card__hints';
+      hints.forEach((hintText) => {
+        const hint = document.createElement('p');
+        hint.className = 'file-card__hint section-subtitle';
+        hint.textContent = hintText;
+        hintList.appendChild(hint);
+      });
+      body.appendChild(hintList);
+    }
+
+    if (options.actions) {
+      const actionsContainer = document.createElement('div');
+      actionsContainer.className = 'file-actions';
+      options.actions.forEach((actionButton) => {
+        actionsContainer.appendChild(actionButton);
+      });
+      body.appendChild(actionsContainer);
+    }
+
+    if (body.children.length) {
+      container.appendChild(body);
+    }
+  }
+
+  return container;
+}
+
+function statusLabel(status = 'recognized') {
+  const map = {
+    recognized: 'Распознано',
+    mapping: 'Нужна сверка',
+    duplicate: 'Дубликат'
+  };
+  return map[status] || status;
+}
+
+function renderAttentionList() {
+  const scenario = state.currentScenario;
+  elements.attentionList.innerHTML = '';
+  const needsMapping = scenario.files.filter((file) => file.status === 'mapping');
+  if (!needsMapping.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Все файлы распознаны. Сверка не требуется.';
+    elements.attentionList.appendChild(message);
+    return;
+  }
+  needsMapping.forEach((file) => {
+    elements.attentionList.appendChild(createFileRow(file));
+  });
+}
+
+function renderDuplicateList() {
+  const scenario = state.currentScenario;
+  elements.duplicateList.innerHTML = '';
+  if (!scenario) {
+    return;
+  }
+  const groups = scenario.duplicateResolutions || [];
+  if (!groups.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Дубликатов не найдено.';
+    elements.duplicateList.appendChild(message);
+    return;
+  }
+
+  const resolvedCount = groups.filter((group) => state.duplicateDecisions.has(group.group)).length;
+  const summary = document.createElement('p');
+  summary.className = 'section-subtitle duplicate-summary';
+  summary.textContent = `Решено: ${resolvedCount} из ${groups.length}`;
+  if (state.lastDuplicateBulkAction && state.lastDuplicateBulkAction !== 'manual') {
+    const note = document.createElement('span');
+    note.className = 'duplicate-summary__note';
+    const optionLabel = getDuplicateBulkLabel(state.lastDuplicateBulkAction);
+    if (optionLabel) {
+      note.textContent = `Массовое решение: ${optionLabel}`;
+      summary.appendChild(note);
+    }
+  }
+  elements.duplicateList.appendChild(summary);
+
+  groups.forEach((group) => {
+    const resolved = state.duplicateDecisions.has(group.group);
+    elements.duplicateList.appendChild(createDuplicateCard(group, resolved));
+  });
+}
+
+function createDuplicateCard(group, resolved) {
+  const card = document.createElement('article');
+  card.className = 'duplicate-card';
+  if (resolved) {
+    card.classList.add('duplicate-card--resolved');
+  }
+  card.setAttribute('aria-label', `Дубликаты: ${group.group}`);
+
+  const header = document.createElement('div');
+  header.className = 'duplicate-card__header';
+  const title = document.createElement('h4');
+  title.textContent = group.group;
+  const count = document.createElement('span');
+  count.className = 'section-subtitle';
+  count.textContent = `${group.files.length} файлов`;
+  header.appendChild(title);
+  header.appendChild(count);
+  const currentDecision = state.duplicateDecisions.get(group.group);
+  if (currentDecision) {
+    const status = document.createElement('span');
+    status.className = 'duplicate-card__status';
+    const actionConfig = DUPLICATE_ACTIONS.find((item) => item.action === currentDecision);
+    status.textContent = actionConfig ? actionConfig.status : 'Решение сохранено';
+    header.appendChild(status);
+  }
+  card.appendChild(header);
+
+  const preview = document.createElement('ul');
+  preview.className = 'duplicate-card__list';
+  group.files.slice(0, 3).forEach((name) => {
+    const original = state.currentScenario.files.find((file) => file.name === name);
+    const item = document.createElement('li');
+    item.textContent = original
+      ? `${original.name} • ${original.periodLabel || original.period || '—'}`
+      : name;
+    preview.appendChild(item);
+  });
+  if (group.files.length > 3) {
+    const more = document.createElement('li');
+    more.className = 'duplicate-card__more';
+    more.textContent = `…и ещё ${group.files.length - 3}`;
+    preview.appendChild(more);
+  }
+  card.appendChild(preview);
+
+  const actions = document.createElement('div');
+  actions.className = 'duplicate-card__actions';
+  DUPLICATE_ACTIONS.forEach((buttonConfig) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'button-secondary duplicate-card__button';
+    const isActive = currentDecision === buttonConfig.action;
+    if (isActive) {
+      btn.classList.add('duplicate-card__button--active');
+    }
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    btn.textContent = buttonConfig.label;
+    btn.addEventListener('click', () => handleDuplicateDecision(group.group, buttonConfig.action));
+    actions.appendChild(btn);
+  });
+
+  card.appendChild(actions);
+
+  const messageText = currentDecision ? group.messages?.[currentDecision] : '';
+  if (messageText) {
+    const note = document.createElement('p');
+    note.className = 'duplicate-card__note';
+    note.textContent = messageText;
+    card.appendChild(note);
+  }
+
+  return card;
+}
+
+function handleDuplicateDecision(groupId, action) {
+  if (!groupId || !action) {
+    return;
+  }
+  const group = getDuplicateGroupById(groupId);
+  if (!group) {
+    return;
+  }
+  state.lastDuplicateBulkAction = null;
+  state.duplicateDecisions.set(group.group, action);
+  renderDuplicateList();
+  updateStartButtonState();
+}
+
+function getDuplicateGroupById(groupId) {
+  return state.currentScenario?.duplicateResolutions?.find((group) => group.group === groupId) || null;
+}
+
+function updateMappingButton() {
+  const scenario = state.currentScenario;
+  if (!scenario || !scenario.mappingSteps || !scenario.mappingSteps.length) {
+    elements.startMapping.textContent = 'Сверка не требуется';
+    elements.startMapping.disabled = true;
+    elements.startMapping.setAttribute('aria-disabled', 'true');
+  } else {
+    if (state.mappingComplete) {
+      elements.startMapping.textContent = 'Проверить дубликаты';
+      elements.startMapping.disabled = false;
+      elements.startMapping.removeAttribute('aria-disabled');
+    } else {
+      elements.startMapping.textContent = 'Открыть мастер сверки';
+      elements.startMapping.disabled = false;
+      elements.startMapping.removeAttribute('aria-disabled');
+    }
+  }
+}
+
+function updateStartButtonState() {
+  const scenarioReady = Boolean(state.currentScenario);
+  const duplicates = state.currentScenario?.duplicateResolutions || [];
+  const duplicatesResolved = duplicates.every((group) => state.duplicateDecisions.has(group.group)) || !duplicates.length;
+  const ready = scenarioReady && state.mappingComplete && duplicatesResolved;
+  elements.startConsolidation.disabled = !ready;
+}
+
+function openDuplicateBulkModal() {
+  if (!elements.duplicateBulkTemplate) {
+    return;
+  }
+
+  const groups = state.currentScenario?.duplicateResolutions || [];
+  if (!groups.length) {
+    focusFirstDuplicateCard();
+    return;
+  }
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'modal-backdrop';
+  const fragment = elements.duplicateBulkTemplate.content.cloneNode(true);
+  const modal = fragment.querySelector('.modal');
+  const optionsContainer = modal.querySelector('[data-role="options"]');
+  const closeButton = modal.querySelector('[data-role="close"]');
+
+  const closeModal = () => {
+    document.body.removeChild(backdrop);
+    document.removeEventListener('keydown', handleKeyDown);
+    if (elements.tabDuplicates) {
+      elements.tabDuplicates.focus();
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeModal();
+    }
+  };
+
+  DUPLICATE_BULK_OPTIONS.forEach((option) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'modal-option';
+    if (option.action === 'manual') {
+      button.classList.add('modal-option--manual');
+    }
+    const title = document.createElement('span');
+    title.className = 'modal-option__title';
+    title.textContent = option.label;
+    const description = document.createElement('span');
+    description.className = 'modal-option__description';
+    description.textContent = option.description;
+    button.appendChild(title);
+    button.appendChild(description);
+    button.addEventListener('click', () => {
+      if (option.action === 'manual') {
+        state.lastDuplicateBulkAction = null;
+        renderDuplicateList();
+        closeModal();
+        requestAnimationFrame(() => {
+          focusFirstDuplicateCard();
+        });
+        return;
+      }
+      applyBulkDuplicateDecision(option.action);
+      closeModal();
+    });
+    optionsContainer.appendChild(button);
+  });
+
+  closeButton.addEventListener('click', closeModal);
+  backdrop.addEventListener('click', (event) => {
+    if (event.target === backdrop) {
+      closeModal();
+    }
+  });
+  modal.addEventListener('click', (event) => {
+    event.stopPropagation();
+  });
+  document.addEventListener('keydown', handleKeyDown);
+
+  backdrop.appendChild(fragment);
+  document.body.appendChild(backdrop);
+  const firstOption = optionsContainer.querySelector('button');
+  if (firstOption) {
+    firstOption.focus();
+  }
+}
+
+function applyBulkDuplicateDecision(action) {
+  const groups = state.currentScenario?.duplicateResolutions || [];
+  state.duplicateDecisions = new Map();
+  groups.forEach((group) => {
+    state.duplicateDecisions.set(group.group, action);
+  });
+  state.lastDuplicateBulkAction = action;
+  renderDuplicateList();
+  updateStartButtonState();
+}
+
+function getDuplicateBulkLabel(action) {
+  const option = DUPLICATE_BULK_OPTIONS.find((item) => item.action === action);
+  return option?.label || '';
+}
+
+function focusFirstDuplicateCard() {
+  if (!elements.duplicateList) {
+    return;
+  }
+  const firstCard = elements.duplicateList.querySelector('.duplicate-card');
+  if (!firstCard) {
+    return;
+  }
+  firstCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  firstCard.setAttribute('tabindex', '-1');
+  try {
+    firstCard.focus({ preventScroll: true });
+  } catch (error) {
+    firstCard.focus();
+  }
+  firstCard.addEventListener(
+    'blur',
+    () => {
+      firstCard.removeAttribute('tabindex');
+    },
+    { once: true }
+  );
+}
+
+function showDuplicatePanel() {
+  if (!elements.tabDuplicates) {
+    return;
+  }
+  elements.tabDuplicates.disabled = false;
+  elements.tabDuplicates.removeAttribute('aria-disabled');
+}
+
+function hideDuplicatePanel() {
+  if (!elements.tabDuplicates) {
+    return;
+  }
+  elements.tabDuplicates.disabled = true;
+  elements.tabDuplicates.setAttribute('aria-disabled', 'true');
+  if (elements.panelDuplicates) {
+    elements.panelDuplicates.setAttribute('hidden', '');
+  }
+  if (elements.tabDuplicates.getAttribute('aria-selected') === 'true') {
+    setActiveMainTab('attention');
+  }
+}
+
+function resetScreensToUpload() {
+  elements.uploadScreen.classList.add('active');
+  elements.progressScreen.classList.remove('active');
+  elements.triadScreen.classList.remove('active');
+  elements.progressIndicator.style.width = '0%';
+  elements.progressValue.textContent = '0%';
+  elements.progressStatus.textContent = 'Подготовка';
+  elements.progressSteps.querySelectorAll('.progress-step').forEach((step, idx) => {
+    step.classList.toggle('active', idx === 0);
+  });
+}
+
+async function fetchJSON(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Не удалось загрузить ${path}`);
+  }
+  return response.json();
+}
+
+async function loadResources() {
+  try {
+    const [config, data] = await Promise.all([
+      fetchJSON('config.json'),
+      fetchJSON('assets/data/mockData.json')
+    ]);
+    return { config, data };
+  } catch (error) {
+    if (window.__FINASSIST_OFFLINE__?.config && window.__FINASSIST_OFFLINE__?.data) {
+      console.warn('Используем встроенные офлайн-данные', error);
+      return {
+        config: window.__FINASSIST_OFFLINE__.config,
+        data: window.__FINASSIST_OFFLINE__.data
+      };
+    }
+    console.error('Не удалось загрузить конфигурацию или данные', error);
+    return null;
+  }
+}
+
+function displayResourceLoadError() {
+  const message = 'Не удалось загрузить демо-данные. Откройте прототип через статический сервер или обновите страницу.';
+  elements.summaryDescription.textContent = message;
+  elements.recognitionLegend.textContent = 'Демо-набор недоступен.';
+  elements.summaryFiles.textContent = '0';
+  elements.summaryCompanies.textContent = '0';
+  elements.summaryPeriods.textContent = '0';
+  elements.summaryFormats.textContent = '—';
+  if (elements.summaryPeriodsDetail) {
+    elements.summaryPeriodsDetail.textContent = 'Периоды появятся после загрузки';
+  }
+  setUploadActionsVisibility(false);
+}
+
+function handleMappingButtonClick() {
+  if (!state.currentScenario) {
+    return;
+  }
+  if (!state.mappingComplete) {
+    openMappingWizard();
+    return;
+  }
+  const duplicates = state.currentScenario?.duplicateResolutions || [];
+  if (!duplicates.length) {
+    setActiveMainTab('duplicates');
+    if (elements.tabDuplicates) {
+      elements.tabDuplicates.focus();
+    }
+    focusFirstDuplicateCard();
+    return;
+  }
+
+  setActiveMainTab('duplicates');
+  if (elements.tabDuplicates) {
+    elements.tabDuplicates.focus();
+  }
+  openDuplicateBulkModal();
+}
+
+function openMappingWizard() {
+  const steps = state.currentScenario?.mappingSteps || [];
+  if (!steps.length) {
+    return;
+  }
+  const backdrop = document.createElement('div');
+  backdrop.className = 'modal-backdrop';
+  const fragment = elements.mappingTemplate.content.cloneNode(true);
+  const modal = fragment.querySelector('.modal');
+  const list = modal.querySelector('[data-role="list"]');
+  list.innerHTML = '';
+
+  steps.forEach((step) => {
+    const item = document.createElement('article');
+    item.className = 'modal-step';
+    const title = document.createElement('h4');
+    title.textContent = step.title;
+    const description = document.createElement('p');
+    description.textContent = step.description;
+    item.appendChild(title);
+    item.appendChild(description);
+    if (step.suggestion) {
+      const suggestion = document.createElement('p');
+      suggestion.className = 'modal-suggestion';
+      suggestion.textContent = step.suggestion;
+      item.appendChild(suggestion);
+    }
+    list.appendChild(item);
+  });
+
+  modal.querySelector('[data-role="cancel"]').addEventListener('click', () => {
+    document.body.removeChild(backdrop);
+  });
+  modal.querySelector('[data-role="confirm"]').addEventListener('click', () => {
+    state.mappingComplete = true;
+    document.body.removeChild(backdrop);
+    updateMappingButton();
+    updateStartButtonState();
+  });
+
+  backdrop.appendChild(fragment);
+  document.body.appendChild(backdrop);
+}
+
+function initializeProgressSteps() {
+  elements.progressSteps.innerHTML = '';
+  state.config.loading.stageLabels.forEach((label, idx) => {
+    const step = document.createElement('span');
+    step.className = 'progress-step';
+    if (idx === 0) {
+      step.classList.add('active');
+    }
+    step.textContent = label;
+    elements.progressSteps.appendChild(step);
+  });
+}
+
+function startConsolidation() {
+  if (!state.currentScenario) {
+    return;
+  }
+  hideDuplicatePanel();
+  elements.uploadScreen.classList.remove('active');
+  elements.progressScreen.classList.add('active');
+  state.progressStart = performance.now();
+  const min = state.config.loading.minSeconds * 1000;
+  const max = state.config.loading.maxSeconds * 1000;
+  state.progressDuration = Math.floor(Math.random() * (max - min + 1)) + min;
+  if (state.progressFrame) {
+    cancelAnimationFrame(state.progressFrame);
+  }
+  state.progressFrame = requestAnimationFrame(animateProgress);
+}
+
+function animateProgress(timestamp) {
+  const current = typeof timestamp === 'number' ? timestamp : performance.now();
+  const elapsed = current - state.progressStart;
+  const progress = Math.min(elapsed / state.progressDuration, 1);
+  elements.progressIndicator.style.width = `${Math.round(progress * 100)}%`;
+  elements.progressValue.textContent = `${Math.round(progress * 100)}%`;
+
+  const stages = elements.progressSteps.querySelectorAll('.progress-step');
+  const activeStage = Math.min(
+    stages.length - 1,
+    Math.floor(progress * stages.length)
+  );
+  stages.forEach((stage, idx) => {
+    stage.classList.toggle('active', idx === activeStage);
+  });
+  elements.progressStatus.textContent = state.config.loading.stageLabels[activeStage] || 'Обработка';
+
+  if (progress < 1) {
+    state.progressFrame = requestAnimationFrame(animateProgress);
+  } else {
+    completeProgress();
+  }
+}
+
+function completeProgress() {
+  state.progressFrame = null;
+  elements.progressScreen.classList.remove('active');
+  elements.triadScreen.classList.add('active');
+  renderConsolidationMetrics();
+  renderEliminationDetails();
+  renderHintsAndRules();
+  renderReceivables();
+  renderInventoryList();
+  switchDetectorPanel(state.activeDetector);
+  renderLiquidation();
+  renderTrafficList();
+  switchTriadPanel('consolidation');
+}
+
+function renderConsolidationMetrics() {
+  const totals = state.currentScenario ? state.data.consolidation.totals : null;
+  if (!totals) {
+    return;
+  }
+  const useAfter = Boolean(state.showAdjustedMetrics);
+  updateAdjustmentToggle();
+  const selected = useAfter ? totals.after : totals.before;
+  const base = state.data.consolidation.baseSummary;
+  elements.consolidationMetrics.innerHTML = '';
+
+  const summaryCard = document.createElement('div');
+  summaryCard.className = 'metric-card';
+  summaryCard.innerHTML = `
+    <span class="metric-value">${base.companies}</span>
+    <span>Компаний в консолидированной базе</span>
+    <p class="metric-note">Файлов учтено: ${base.files}. Период: ${base.period}. Удалено пар: ${base.eliminatedPairs}.</p>
+  `;
+  elements.consolidationMetrics.appendChild(summaryCard);
+
+  const metrics = [
+    { key: 'revenue', label: 'Выручка' },
+    { key: 'cogs', label: 'Себестоимость' },
+    { key: 'grossMargin', label: 'Валовая маржа' },
+    { key: 'interestPayable', label: 'Проценты к уплате' },
+    { key: 'interestReceivable', label: 'Проценты к получению' }
+  ];
+
+  metrics.forEach((metric) => {
+    if (selected[metric.key] === undefined) {
+      return;
+    }
+    if (useAfter && Number(selected[metric.key]) === 0) {
+      return;
+    }
+    const card = document.createElement('div');
+    card.className = 'metric-card';
+    card.innerHTML = `
+      <span>${metric.label}</span>
+      <span class="metric-value">${formatCurrency(selected[metric.key])}</span>
+    `;
+    elements.consolidationMetrics.appendChild(card);
+  });
+
+  if (!useAfter) {
+    const intraCard = document.createElement('div');
+    intraCard.className = 'metric-card';
+    intraCard.innerHTML = `
+      <span>Внутригрупповая выручка</span>
+      <span class="metric-value">${formatCurrency(totals.before.intraRevenue)}</span>
+      <p class="metric-note">До исключения обороты остаются в отчётности.</p>
+    `;
+    elements.consolidationMetrics.appendChild(intraCard);
+  }
+
+  if (selected.note) {
+    const note = document.createElement('p');
+    note.className = 'metric-note';
+    note.textContent = selected.note;
+    elements.consolidationMetrics.appendChild(note);
+  }
+}
+
+function toggleAdjustmentMode() {
+  state.showAdjustedMetrics = !state.showAdjustedMetrics;
+  renderConsolidationMetrics();
+}
+
+function updateAdjustmentToggle() {
+  if (!elements.toggleAdjustments) {
+    return;
+  }
+  const pressed = Boolean(state.showAdjustedMetrics);
+  elements.toggleAdjustments.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+  elements.toggleAdjustments.textContent = pressed
+    ? 'Показать до исключений'
+    : 'Показать после исключений';
+}
+
+function renderEliminationDetails() {
+  const list = state.data.consolidation.eliminationEntries;
+  elements.eliminationDetails.innerHTML = '';
+  list.forEach((entry) => {
+    const item = document.createElement('div');
+    item.className = 'elimination-item';
+    item.innerHTML = `
+      <strong>${entry.pair}</strong>
+      <p class="section-subtitle">${entry.description}</p>
+      <p class="section-subtitle">${entry.metric}: ${formatCurrency(entry.amount)}</p>
+    `;
+    elements.eliminationDetails.appendChild(item);
+  });
+}
+
+function renderHintsAndRules() {
+  elements.consolidationHints.innerHTML = '';
+  state.data.consolidation.infoNotes.forEach((note) => {
+    const p = document.createElement('p');
+    p.textContent = note;
+    elements.consolidationHints.appendChild(p);
+  });
+  elements.consolidationRules.innerHTML = '';
+  state.data.consolidation.ruleHints.forEach((hint) => {
+    const p = document.createElement('p');
+    p.textContent = hint;
+    elements.consolidationRules.appendChild(p);
+  });
+}
+
+function toggleEliminationList() {
+  const hidden = elements.eliminationDetails.hasAttribute('hidden');
+  if (hidden) {
+    if (!elements.eliminationDetails.childElementCount) {
+      renderEliminationDetails();
+    }
+    elements.eliminationDetails.removeAttribute('hidden');
+    elements.showEliminations.textContent = 'Скрыть снятые обороты';
+    elements.showEliminations.setAttribute('aria-expanded', 'true');
+    elements.eliminationDetails.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  } else {
+    elements.eliminationDetails.setAttribute('hidden', '');
+    elements.showEliminations.textContent = 'Показать снятые внутригрупповые обороты';
+    elements.showEliminations.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function renderReceivables() {
+  elements.receivablesList.innerHTML = '';
+  const threshold = state.threshold || state.config.receivables.defaultThreshold;
+  const list = state.data.detectors.receivables;
+  list.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'receivable-row';
+    const counterparty = document.createElement('span');
+    counterparty.textContent = `${item.counterparty} • ${item.company}`;
+    row.appendChild(counterparty);
+    const days = document.createElement('span');
+    days.textContent = `${item.days} дней`;
+    const highlight = getReceivableHighlight(item.days, threshold);
+    if (highlight) {
+      days.classList.add(highlight);
+    }
+    row.appendChild(days);
+    const amount = document.createElement('span');
+    amount.textContent = formatCurrency(item.amount);
+    if (highlight) {
+      amount.classList.add(highlight);
+    }
+    row.appendChild(amount);
+    const source = document.createElement('span');
+    source.textContent = item.source;
+    row.appendChild(source);
+    elements.receivablesList.appendChild(row);
+  });
+}
+
+function getReceivableHighlight(days, threshold) {
+  if (days >= threshold) {
+    return 'highlight-red';
+  }
+  if (days >= threshold - 30) {
+    return 'highlight-yellow';
+  }
+  return 'highlight-green';
+}
+
+function addReceivablesToTraffic() {
+  const threshold = state.threshold || state.config.receivables.defaultThreshold;
+  const list = state.data.detectors.receivables.filter((item) => item.days >= threshold);
+  list.forEach((item) => state.flaggedReceivables.add(item.counterparty));
+  elements.trafficMessage.textContent = list.length
+    ? `Добавлено в светофор: ${list.length}.`
+    : 'По текущему порогу просрочки нет.';
+  renderTrafficList();
+}
+
+function initializeInventoryFilters() {
+  if (!state.config) {
+    return;
+  }
+  elements.inventoryFilters.classList.add('inventory-filters');
+  elements.inventoryFilters.innerHTML = '';
+  state.config.inventoryMarkers.forEach((marker) => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = marker;
+    checkbox.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        state.inventoryFilters.add(marker);
+      } else {
+        state.inventoryFilters.delete(marker);
+      }
+      renderInventoryList();
+    });
+    const span = document.createElement('span');
+    span.textContent = marker;
+    label.appendChild(checkbox);
+    label.appendChild(span);
+    elements.inventoryFilters.appendChild(label);
+  });
+}
+
+function renderInventoryList() {
+  elements.inventoryList.innerHTML = '';
+  const filters = state.inventoryFilters;
+  const list = state.data.detectors.inventory;
+  list.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'inventory-row';
+    const name = document.createElement('span');
+    name.textContent = `${item.item} • ${item.company}`;
+    row.appendChild(name);
+    const amount = document.createElement('span');
+    amount.textContent = formatCurrency(item.amount);
+    row.appendChild(amount);
+    const source = document.createElement('span');
+    source.textContent = item.source;
+    row.appendChild(source);
+    const flags = document.createElement('div');
+    flags.className = 'inventory-flags';
+    item.issues.forEach((issue) => {
+      const badge = document.createElement('span');
+      badge.textContent = issue;
+      flags.appendChild(badge);
+    });
+    flags.style.gridColumn = '1 / -1';
+    row.appendChild(flags);
+
+    if (!filters.size) {
+      highlightInventoryRow(row, item.issues);
+    } else if (item.issues.some((issue) => filters.has(issue))) {
+      highlightInventoryRow(row, item.issues);
+    }
+
+    elements.inventoryList.appendChild(row);
+  });
+}
+
+function highlightInventoryRow(row, issues) {
+  const isCritical = issues.includes('брак') || issues.includes('истёк срок');
+  const severityClass = isCritical ? 'highlight-red' : 'highlight-yellow';
+  row.classList.add(isCritical ? 'inventory-row--critical' : 'inventory-row--warning');
+  row.querySelectorAll('span').forEach((span) => span.classList.add(severityClass));
+}
+
+function resetLiquidationView() {
+  elements.liquidationAfterSummary.textContent = 'Нажмите «Очистить», чтобы применить сценарий.';
+  elements.ownerStatement.textContent = '';
+  elements.cleanBalance.disabled = false;
+  elements.cleanBalance.textContent = 'Очистить';
+  elements.liquidationAdjustments.innerHTML = '';
+  state.data.liquidation.adjustments.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = `${item.label}: ${formatCurrency(item.impact)} (${item.reason}, источник: ${item.source})`;
+    elements.liquidationAdjustments.appendChild(li);
+  });
+}
+
+function renderLiquidation() {
+  const data = state.data.liquidation;
+  elements.liquidationBeforeSummary.textContent = `Собственный капитал: ${formatCurrency(data.before.equity)} • Денежные средства: ${formatCurrency(data.before.cash)}`;
+  elements.liquidationAssets.innerHTML = '';
+  data.before.assets.forEach((asset) => {
+    const li = document.createElement('li');
+    li.textContent = `${asset.label}: ${formatCurrency(asset.amount)}`;
+    elements.liquidationAssets.appendChild(li);
+  });
+  if (state.liquidationCleaned) {
+    elements.liquidationAfterSummary.textContent = `Капитал после очистки: ${formatCurrency(data.after.equity)} • Денежный остаток: ${formatCurrency(data.after.cash)}`;
+    elements.ownerStatement.textContent = data.after.ownerStatement;
+  }
+}
+
+function applyLiquidationScenario() {
+  state.liquidationCleaned = true;
+  renderLiquidation();
+  elements.cleanBalance.disabled = true;
+  elements.cleanBalance.textContent = 'Очистка выполнена';
+}
+
+function initializeTrafficFilters() {
+  const labels = state.data.trafficLight.statusLabels;
+  elements.trafficFilters.innerHTML = '';
+  Object.entries(labels).forEach(([value, label]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'button-secondary';
+    button.textContent = label;
+    button.dataset.value = value;
+    if (value === 'all') {
+      button.classList.add('active');
+      button.setAttribute('aria-pressed', 'true');
+    } else {
+      button.setAttribute('aria-pressed', 'false');
+    }
+    button.addEventListener('click', () => {
+      state.trafficFilter = value;
+      elements.trafficFilters.querySelectorAll('button').forEach((btn) => {
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
+      });
+      button.classList.add('active');
+      button.setAttribute('aria-pressed', 'true');
+      renderTrafficList();
+    });
+    elements.trafficFilters.appendChild(button);
+  });
+}
+
+function initializeTrafficCompanies() {
+  const companies = new Set(['all']);
+  state.data.trafficLight.items.forEach((item) => companies.add(item.company));
+  elements.trafficCompany.innerHTML = '';
+  companies.forEach((company) => {
+    const option = document.createElement('option');
+    option.value = company;
+    option.textContent = company === 'all' ? 'Все компании' : company;
+    elements.trafficCompany.appendChild(option);
+  });
+  elements.trafficCompany.value = 'all';
+}
+
+function renderTrafficList() {
+  elements.trafficList.innerHTML = '';
+  const filter = state.trafficFilter;
+  const companyFilter = state.trafficCompany;
+  const flagged = state.flaggedReceivables;
+  state.data.trafficLight.items
+    .map((item) => {
+      const flaggedStatus = flagged.has(item.name) ? 'red' : item.status;
+      return { ...item, status: flaggedStatus, flagged: flagged.has(item.name) };
+    })
+    .filter((item) => (filter === 'all' ? true : item.status === filter))
+    .filter((item) => (companyFilter === 'all' ? true : item.company === companyFilter))
+    .forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'traffic-card';
+      const header = document.createElement('div');
+      header.innerHTML = `<strong>${item.name}</strong> • ${item.company}`;
+      card.appendChild(header);
+      const status = document.createElement('span');
+      status.className = 'status-pill';
+      status.dataset.status = item.status;
+      status.textContent = state.data.trafficLight.statusLabels[item.status] || item.status;
+      card.appendChild(status);
+      const financial = document.createElement('p');
+      financial.className = 'section-subtitle';
+      financial.textContent = item.financial;
+      card.appendChild(financial);
+      const legal = document.createElement('p');
+      legal.className = 'section-subtitle';
+      legal.textContent = item.legal;
+      card.appendChild(legal);
+      if (item.note) {
+        const note = document.createElement('p');
+        note.className = 'section-subtitle';
+        note.textContent = item.note;
+        card.appendChild(note);
+      }
+      if (item.flagged) {
+        const badge = document.createElement('p');
+        badge.className = 'section-subtitle';
+        badge.textContent = 'Добавлено из детектора дебиторки.';
+        card.appendChild(badge);
+      }
+      elements.trafficList.appendChild(card);
+    });
+  if (!elements.trafficList.children.length) {
+    const message = document.createElement('p');
+    message.className = 'section-subtitle';
+    message.textContent = 'Нет контрагентов по выбранному фильтру.';
+    elements.trafficList.appendChild(message);
+  }
+}
+
+function switchDetectorPanel(target, button) {
+  const nextTarget = target === 'inventory' ? 'inventory' : 'receivables';
+  state.activeDetector = nextTarget;
+
+  const sections = [
+    { key: 'receivables', element: elements.detectorReceivables },
+    { key: 'inventory', element: elements.detectorInventory }
+  ];
+
+  sections.forEach((section) => {
+    if (!section.element) {
+      return;
+    }
+    if (section.key === nextTarget) {
+      section.element.removeAttribute('hidden');
+    } else {
+      section.element.setAttribute('hidden', '');
+    }
+  });
+
+  if (Array.isArray(elements.detectorTabButtons)) {
+    elements.detectorTabButtons.forEach((btn) => {
+      if (!btn) {
+        return;
+      }
+      const isActive = btn.dataset.detector === nextTarget;
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  if (button) {
+    button.focus();
+  }
+}
+
+function switchTriadPanel(target, button) {
+  document.querySelectorAll('.triad-panel').forEach((panel) => {
+    panel.hidden = true;
+  });
+  document.getElementById(`panel-${target}`).hidden = false;
+  elements.triadNavButtons.forEach((btn) => btn.setAttribute('aria-pressed', 'false'));
+  if (button) {
+    button.setAttribute('aria-pressed', 'true');
+  } else {
+    const activeButton = Array.from(elements.triadNavButtons).find((btn) => btn.dataset.target === target);
+    if (activeButton) {
+      activeButton.setAttribute('aria-pressed', 'true');
+    }
+  }
+}
+
+function createTabKeydownHandler(tabs) {
+  return (event) => {
+    const enabledTabs = tabs.filter((tab) => tab && !tab.disabled);
+    if (!enabledTabs.length) {
+      return;
+    }
+    const currentIndex = enabledTabs.indexOf(event.target);
+    if (currentIndex === -1) {
+      return;
+    }
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      const next = enabledTabs[(currentIndex + 1) % enabledTabs.length];
+      next.focus();
+      next.click();
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      const prev = enabledTabs[(currentIndex - 1 + enabledTabs.length) % enabledTabs.length];
+      prev.focus();
+      prev.click();
+    } else if (event.key === 'Home') {
+      const first = enabledTabs[0];
+      first.focus();
+      first.click();
+    } else if (event.key === 'End') {
+      const last = enabledTabs[enabledTabs.length - 1];
+      last.focus();
+      last.click();
+    }
+  };
+}
+
+function setActiveMainTab(tab) {
+  const mapping = {
+    attention: { button: elements.tabAttention, panel: elements.panelAttention },
+    duplicates: { button: elements.tabDuplicates, panel: elements.panelDuplicates },
+    catalog: { button: elements.tabCatalog, panel: elements.panelCatalog }
+  };
+
+  let target = mapping[tab];
+  if (!target || !target.button || target.button.disabled) {
+    target = Object.values(mapping).find((entry) => entry.button && !entry.button.disabled);
+  }
+  if (!target || !target.button || !target.panel) {
+    return;
+  }
+
+  Object.values(mapping).forEach((entry) => {
+    if (!entry.button || !entry.panel) {
+      return;
+    }
+    const isActive = entry.button === target.button;
+    entry.button.setAttribute('aria-selected', String(isActive));
+    if (isActive) {
+      entry.panel.removeAttribute('hidden');
+    } else {
+      entry.panel.setAttribute('hidden', '');
+    }
+  });
+}
+
+function setActiveTab(tab) {
+  if (tab === 'companies') {
+    elements.tabCompanies.setAttribute('aria-selected', 'true');
+    elements.tabPeriods.setAttribute('aria-selected', 'false');
+    elements.panelCompanies.hidden = false;
+    elements.panelPeriods.hidden = true;
+  } else {
+    elements.tabCompanies.setAttribute('aria-selected', 'false');
+    elements.tabPeriods.setAttribute('aria-selected', 'true');
+    elements.panelCompanies.hidden = true;
+    elements.panelPeriods.hidden = false;
+  }
+}
+
+function renderFinalScreen() {
+  const summary = state.data.finalSummary;
+  elements.finalHeadline.textContent = summary.headline;
+  elements.finalPoints.innerHTML = '';
+  summary.points.forEach((point) => {
+    const li = document.createElement('li');
+    li.textContent = point;
+    elements.finalPoints.appendChild(li);
+  });
+  elements.finalDisclaimer.textContent = summary.disclaimer;
+}
+
+function updateCTA() {
+  if (state.config?.ctaUrl) {
+    elements.ctaButton.href = state.config.ctaUrl;
+  }
+}
+
+function formatCurrency(value) {
+  if (typeof value !== 'number') {
+    return value;
+  }
+  return `${numberFormatter.format(value)} ₽`;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1718,11 +1718,10 @@ function initializeTrafficFilters() {
   Object.entries(labels).forEach(([value, label]) => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'button-secondary';
+    button.className = 'detector-tab-btn traffic-filter-btn';
     button.textContent = label;
     button.dataset.value = value;
     if (value === 'all') {
-      button.classList.add('active');
       button.setAttribute('aria-pressed', 'true');
     } else {
       button.setAttribute('aria-pressed', 'false');
@@ -1730,10 +1729,8 @@ function initializeTrafficFilters() {
     button.addEventListener('click', () => {
       state.trafficFilter = value;
       elements.trafficFilters.querySelectorAll('button').forEach((btn) => {
-        btn.classList.remove('active');
         btn.setAttribute('aria-pressed', 'false');
       });
-      button.classList.add('active');
       button.setAttribute('aria-pressed', 'true');
       renderTrafficList();
     });
@@ -1769,6 +1766,7 @@ function renderTrafficList() {
     .forEach((item) => {
       const card = document.createElement('article');
       card.className = 'traffic-card';
+      card.dataset.status = item.status;
       const header = document.createElement('div');
       header.innerHTML = `<strong>${item.name}</strong> • ${item.company}`;
       card.appendChild(header);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', init);
 
 async function init() {
   cacheElements();
+  setSummaryVisibility(false);
   initializeTheme();
   setUploadActionsVisibility(false);
   setDemoScenarioAvailability(false);
@@ -87,6 +88,8 @@ function cacheElements() {
   elements.fileInput = document.getElementById('fileInput');
   elements.demoScenario = document.getElementById('demoScenario');
   elements.themeToggle = document.getElementById('themeToggle');
+  elements.summaryBadges = document.querySelector('.summary-badges');
+  elements.uploadSummary = document.querySelector('.upload-summary');
   elements.summaryFiles = document.getElementById('summary-files');
   elements.summaryCompanies = document.getElementById('summary-companies');
   elements.summaryPeriods = document.getElementById('summary-periods');
@@ -94,6 +97,8 @@ function cacheElements() {
   elements.summaryDescription = document.getElementById('summary-description');
   elements.summaryPeriodsDetail = document.getElementById('summary-periods-detail');
   elements.recognitionLegend = document.getElementById('recognition-legend');
+  elements.dropHint = document.getElementById('dropHint');
+  elements.dropInfoNote = document.getElementById('dropInfoNote');
   elements.badgeFiles = document.getElementById('badge-files');
   elements.badgeCompanies = document.getElementById('badge-companies');
   elements.badgePeriods = document.getElementById('badge-periods');
@@ -422,8 +427,23 @@ function setUploadActionsVisibility(visible) {
   updateWorkflowButton();
 }
 
+function setSummaryVisibility(visible) {
+  const targets = [elements.summaryBadges, elements.uploadSummary, elements.dropInfoNote];
+  targets.forEach((element) => {
+    if (!element) {
+      return;
+    }
+    if (visible) {
+      element.removeAttribute('hidden');
+    } else {
+      element.setAttribute('hidden', '');
+    }
+  });
+}
+
 function renderScenarioSummary() {
   const scenario = state.currentScenario;
+  setSummaryVisibility(true);
   elements.summaryFiles.textContent = scenario.summary.files;
   elements.summaryCompanies.textContent = scenario.summary.companies;
   elements.summaryPeriods.textContent = scenario.summary.periods;
@@ -1322,14 +1342,9 @@ async function loadResources() {
 
 function displayResourceLoadError() {
   const message = 'Не удалось загрузить демо-данные. Откройте прототип через статический сервер или обновите страницу.';
-  elements.summaryDescription.textContent = message;
-  elements.recognitionLegend.textContent = 'Демо-набор недоступен.';
-  elements.summaryFiles.textContent = '0';
-  elements.summaryCompanies.textContent = '0';
-  elements.summaryPeriods.textContent = '0';
-  elements.summaryFormats.textContent = '—';
-  if (elements.summaryPeriodsDetail) {
-    elements.summaryPeriodsDetail.textContent = 'Периоды появятся после загрузки';
+  setSummaryVisibility(false);
+  if (elements.dropHint) {
+    elements.dropHint.textContent = message;
   }
   setUploadActionsVisibility(false);
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -76,7 +76,6 @@ async function init() {
   initializeInventoryFilters();
   initializeTrafficFilters();
   initializeTrafficCompanies();
-  renderFinalScreen();
   updateCTA();
   renderTrafficList();
 
@@ -127,7 +126,6 @@ function cacheElements() {
   elements.showEliminations = document.getElementById('showEliminations');
   elements.eliminationDetails = document.getElementById('eliminationDetails');
   elements.consolidationHints = document.getElementById('consolidationHints');
-  elements.consolidationRules = document.getElementById('consolidationRules');
   elements.thresholdRange = document.getElementById('thresholdRange');
   elements.thresholdValue = document.getElementById('thresholdValue');
   elements.receivablesList = document.getElementById('receivablesList');
@@ -147,9 +145,6 @@ function cacheElements() {
   elements.trafficFilters = document.getElementById('trafficFilters');
   elements.trafficCompany = document.getElementById('trafficCompany');
   elements.trafficList = document.getElementById('trafficList');
-  elements.finalHeadline = document.getElementById('finalHeadline');
-  elements.finalPoints = document.getElementById('finalPoints');
-  elements.finalDisclaimer = document.getElementById('finalDisclaimer');
   elements.ctaButton = document.getElementById('ctaButton');
   elements.mappingTemplate = document.getElementById('mappingStepTemplate');
   elements.duplicateBulkTemplate = document.getElementById('duplicateBulkTemplate');
@@ -625,24 +620,31 @@ function renderPeriodGroups(files) {
       let batchCount = 0;
       while (periodIndex < periods.length && batchCount < FILE_BATCH_SIZE) {
         const [periodLabel, periodFiles] = periods[periodIndex];
-        const card = document.createElement('article');
+        const card = document.createElement('details');
         card.className = 'period-card';
-        const header = document.createElement('div');
+        const header = document.createElement('summary');
         header.className = 'period-card__header';
         const title = document.createElement('h4');
         title.textContent = periodLabel;
         const count = document.createElement('span');
         count.className = 'section-subtitle';
         count.textContent = `${periodFiles.length} файлов`;
+        const chevron = document.createElement('span');
+        chevron.className = 'period-card__chevron';
+        chevron.setAttribute('aria-hidden', 'true');
         header.appendChild(title);
         header.appendChild(count);
+        header.appendChild(chevron);
         card.appendChild(header);
+        const content = document.createElement('div');
+        content.className = 'period-card__content';
         const list = document.createElement('div');
         list.className = 'period-card__list';
         periodFiles.forEach((file) => {
           list.appendChild(createFileRow(file, { compact: true }));
         });
-        card.appendChild(list);
+        content.appendChild(list);
+        card.appendChild(content);
         fragment.appendChild(card);
         periodIndex += 1;
         batchCount += 1;
@@ -1577,12 +1579,6 @@ function renderHintsAndRules() {
     p.textContent = note;
     elements.consolidationHints.appendChild(p);
   });
-  elements.consolidationRules.innerHTML = '';
-  state.data.consolidation.ruleHints.forEach((hint) => {
-    const p = document.createElement('p');
-    p.textContent = hint;
-    elements.consolidationRules.appendChild(p);
-  });
 }
 
 function toggleEliminationList() {
@@ -1972,18 +1968,6 @@ function setActiveTab(tab) {
     elements.panelCompanies.hidden = true;
     elements.panelPeriods.hidden = false;
   }
-}
-
-function renderFinalScreen() {
-  const summary = state.data.finalSummary;
-  elements.finalHeadline.textContent = summary.headline;
-  elements.finalPoints.innerHTML = '';
-  summary.points.forEach((point) => {
-    const li = document.createElement('li');
-    li.textContent = point;
-    elements.finalPoints.appendChild(li);
-  });
-  elements.finalDisclaimer.textContent = summary.disclaimer;
 }
 
 function updateCTA() {

--- a/assets/js/offlineData.js
+++ b/assets/js/offlineData.js
@@ -1,0 +1,4725 @@
+// Автогенерированный файл для офлайн-режима.
+// Обновите вручную при изменении исходных JSON.
+
+window.__FINASSIST_OFFLINE__ = {
+  config: {
+  "ctaUrl": "https://solward.example/test-drive",
+  "loading": {
+    "minSeconds": 25,
+    "maxSeconds": 35,
+    "stageLabels": [
+      "Импорт",
+      "Нормализация",
+      "Сшивка",
+      "Проверки",
+      "Готово"
+    ]
+  },
+  "receivables": {
+    "defaultThreshold": 180,
+    "minDays": 100,
+    "maxDays": 270
+  },
+  "inventoryMarkers": [
+    "долго лежит",
+    "истёк срок",
+    "брак"
+  ]
+},
+  data: {
+  "uploadScenarios": [
+    {
+      "id": "singleCompany",
+      "label": "Одна компания, много файлов",
+      "summary": {
+        "companies": 1,
+        "files": 12,
+        "periods": 4,
+        "formats": [
+          "xlsx",
+          "csv"
+        ],
+        "description": "Разнобой периодов и форматов для одной компании"
+      },
+      "recognition": {
+        "recognized": 7,
+        "needsMapping": 3,
+        "duplicates": 2
+      },
+      "files": [
+        {
+          "name": "ОСВ_январь.xlsx",
+          "company": "Компания А",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "ОФР_Q1.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "ОФР_Q1_v2.csv",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "duplicate",
+          "duplicateGroup": "ОФР_Q1",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "баланс_31-03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "запасы_февраль.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Сопоставить с классификатором запасов",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Дополните справочник подразделений для новых кодов",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "дебиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "кредиторка_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "mapping",
+          "mappingHints": [
+            "Требуется указать тип отчёта",
+            "Дополните справочник подразделений для новых кодов",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "движение_денег.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "инвентаризация_2023.csv",
+          "company": "Компания А",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Уточнить период учёта",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "реестр_контрагентов.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "юрисобытия_2024.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "архив_выручка_2022.xlsx",
+          "company": "Компания А",
+          "period": "2022",
+          "periodLabel": "2022",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распознала компанию по шапке файлов.",
+          "suggestion": "Компания А • ИНН 7701234567"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По заголовку файла предполагаем ОФР за период.",
+          "suggestion": "ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Подсказка из имени файла",
+          "suggestion": "I квартал 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "ОФР_Q1",
+          "files": [
+            "ОФР_Q1.csv",
+            "ОФР_Q1_v2.csv"
+          ],
+          "messages": {
+            "keepNew": "Новая версия сохранена. Предыдущая отправлена в архив.",
+            "keepOld": "Оставили исходный файл. Новую выгрузку пометили как резерв.",
+            "merge": "Склейка завершена. Строк объединено: 184."
+          }
+        }
+      ]
+    },
+    {
+      "id": "groupUpload",
+      "label": "Группа компаний, много файлов",
+      "summary": {
+        "companies": 60,
+        "files": 331,
+        "periods": 16,
+        "formats": [
+          "csv",
+          "txt",
+          "xlsx"
+        ],
+        "description": "60 компаний, более 300 файлов и разные форматы выгрузок"
+      },
+      "recognition": {
+        "recognized": 272,
+        "needsMapping": 53,
+        "duplicates": 6
+      },
+      "files": [
+        {
+          "name": "Компания_01/OSV_2024_Q1.xlsx",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_01/PnL_2024_Q1.csv",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_01/Balance_20240331.xlsx",
+          "company": "Компания 01",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_01/Receivables_2024_Q1.xlsx",
+          "company": "Компания 01",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_02/OSV_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_02/PnL_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_02/Balance_20240630.xlsx",
+          "company": "Компания 02",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_02/Receivables_2024_Q2.xlsx",
+          "company": "Компания 02",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_02/Inventory_2024_05.csv",
+          "company": "Компания 02",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_03/OSV_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_03/PnL_2023_Q4.csv",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_03/Balance_20231231.xlsx",
+          "company": "Компания 03",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_03/Receivables_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_03/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 03",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_04/OSV_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_04/PnL_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_04/Balance_20230930.xlsx",
+          "company": "Компания 04",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_04/Receivables_2023_Q3.xlsx",
+          "company": "Компания 04",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_04/Inventory_2023_08.csv",
+          "company": "Компания 04",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Привяжите показатели к управленческой статье движения",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_04/Projects_2023.csv",
+          "company": "Компания 04",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_05/OSV_2024_Q1.xlsx",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_05/PnL_2024_Q1.csv",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_05/Balance_20240331.xlsx",
+          "company": "Компания 05",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_05/Receivables_2024_Q1.xlsx",
+          "company": "Компания 05",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_05/Legal_2024.csv",
+          "company": "Компания 05",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_06/OSV_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_06/PnL_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_06/Balance_20240630.xlsx",
+          "company": "Компания 06",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_06/Receivables_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_06/Inventory_2024_05.csv",
+          "company": "Компания 06",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_06/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 06",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_07/OSV_2023_Q4.xlsx",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_07/PnL_2023_Q4.csv",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_07/Balance_20231231.xlsx",
+          "company": "Компания 07",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_07/Receivables_2023_Q4.xlsx",
+          "company": "Компания 07",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_07/Loans_2023_10.txt",
+          "company": "Компания 07",
+          "period": "2023-10",
+          "periodLabel": "Октябрь 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_08/OSV_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_08/PnL_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_08/Balance_20230930.xlsx",
+          "company": "Компания 08",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_08/Receivables_2023_Q3.xlsx",
+          "company": "Компания 08",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_08/Inventory_2023_08.csv",
+          "company": "Компания 08",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_08/Projects_2023.csv",
+          "company": "Компания 08",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Дополните справочник подразделений для новых кодов",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_09/OSV_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_09/PnL_2024_Q1.csv",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_09/Balance_20240331.xlsx",
+          "company": "Компания 09",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_09/Receivables_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_09/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 09",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_10/OSV_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_10/PnL_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_10/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_10_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_10/Balance_20240630.xlsx",
+          "company": "Компания 10",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_10/Receivables_2024_Q2.xlsx",
+          "company": "Компания 10",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_10/Inventory_2024_05.csv",
+          "company": "Компания 10",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_10/Legal_2024.csv",
+          "company": "Компания 10",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_11/OSV_2023_Q4.xlsx",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_11/PnL_2023_Q4.csv",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_11/Balance_20231231.xlsx",
+          "company": "Компания 11",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_11/Receivables_2023_Q4.xlsx",
+          "company": "Компания 11",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/OSV_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_12/PnL_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/Balance_20230930.xlsx",
+          "company": "Компания 12",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_12/Receivables_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_12/Inventory_2023_08.csv",
+          "company": "Компания 12",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_12/Projects_2023.csv",
+          "company": "Компания 12",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_12/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 12",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_13/OSV_2024_Q1.xlsx",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_13/PnL_2024_Q1.csv",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_13/Balance_20240331.xlsx",
+          "company": "Компания 13",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_13/Receivables_2024_Q1.xlsx",
+          "company": "Компания 13",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_14/OSV_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_14/PnL_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_14/Balance_20240630.xlsx",
+          "company": "Компания 14",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_14/Receivables_2024_Q2.xlsx",
+          "company": "Компания 14",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_14/Inventory_2024_05.csv",
+          "company": "Компания 14",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_14/Loans_2024_04.txt",
+          "company": "Компания 14",
+          "period": "2024-04",
+          "periodLabel": "Апрель 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_15/OSV_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_15/PnL_2023_Q4.csv",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_15/Balance_20231231.xlsx",
+          "company": "Компания 15",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_15/Receivables_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_15/Legal_2023.csv",
+          "company": "Компания 15",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_15/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 15",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_16/OSV_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_16/PnL_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_16/Balance_20230930.xlsx",
+          "company": "Компания 16",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_16/Receivables_2023_Q3.xlsx",
+          "company": "Компания 16",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_16/Inventory_2023_08.csv",
+          "company": "Компания 16",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Уточните источник данных — файл собран вручную",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_16/Projects_2023.csv",
+          "company": "Компания 16",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_17/OSV_2024_Q1.xlsx",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_17/PnL_2024_Q1.csv",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_17/Balance_20240331.xlsx",
+          "company": "Компания 17",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_17/Receivables_2024_Q1.xlsx",
+          "company": "Компания 17",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/OSV_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_18/PnL_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/Balance_20240630.xlsx",
+          "company": "Компания 18",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_18/Receivables_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_18/Inventory_2024_05.csv",
+          "company": "Компания 18",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_18/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 18",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_19/OSV_2023_Q4.xlsx",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_19/PnL_2023_Q4.csv",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_19/Balance_20231231.xlsx",
+          "company": "Компания 19",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_19/Receivables_2023_Q4.xlsx",
+          "company": "Компания 19",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_20/OSV_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_20/PnL_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_20/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_20_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_20/Balance_20230930.xlsx",
+          "company": "Компания 20",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_20/Receivables_2023_Q3.xlsx",
+          "company": "Компания 20",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_20/Inventory_2023_08.csv",
+          "company": "Компания 20",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Дополните справочник подразделений для новых кодов",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_20/Projects_2023.csv",
+          "company": "Компания 20",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Уточните источник данных — файл собран вручную",
+            "Привяжите показатели к управленческой статье движения",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_20/Legal_2023.csv",
+          "company": "Компания 20",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_21/OSV_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_21/PnL_2024_Q1.csv",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_21/Balance_20240331.xlsx",
+          "company": "Компания 21",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_21/Receivables_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_21/Loans_2024_01.txt",
+          "company": "Компания 21",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Привяжите показатели к управленческой статье движения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_21/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 21",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_22/OSV_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_22/PnL_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_22/Balance_20240630.xlsx",
+          "company": "Компания 22",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_22/Receivables_2024_Q2.xlsx",
+          "company": "Компания 22",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_22/Inventory_2024_05.csv",
+          "company": "Компания 22",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Уточните источник данных — файл собран вручную",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_23/OSV_2023_Q4.xlsx",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_23/PnL_2023_Q4.csv",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_23/Balance_20231231.xlsx",
+          "company": "Компания 23",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_23/Receivables_2023_Q4.xlsx",
+          "company": "Компания 23",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/OSV_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_24/PnL_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/Balance_20230930.xlsx",
+          "company": "Компания 24",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_24/Receivables_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_24/Inventory_2023_08.csv",
+          "company": "Компания 24",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Уточните источник данных — файл собран вручную",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_24/Projects_2023.csv",
+          "company": "Компания 24",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Уточните источник данных — файл собран вручную",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_24/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 24",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_25/OSV_2024_Q1.xlsx",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_25/PnL_2024_Q1.csv",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_25/Balance_20240331.xlsx",
+          "company": "Компания 25",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_25/Receivables_2024_Q1.xlsx",
+          "company": "Компания 25",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_25/Legal_2024.csv",
+          "company": "Компания 25",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_26/OSV_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_26/PnL_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_26/Balance_20240630.xlsx",
+          "company": "Компания 26",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_26/Receivables_2024_Q2.xlsx",
+          "company": "Компания 26",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_26/Inventory_2024_05.csv",
+          "company": "Компания 26",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_27/OSV_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_27/PnL_2023_Q4.csv",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_27/Balance_20231231.xlsx",
+          "company": "Компания 27",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_27/Receivables_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_27/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 27",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_28/OSV_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_28/PnL_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_28/Balance_20230930.xlsx",
+          "company": "Компания 28",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_28/Receivables_2023_Q3.xlsx",
+          "company": "Компания 28",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_28/Inventory_2023_08.csv",
+          "company": "Компания 28",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_28/Projects_2023.csv",
+          "company": "Компания 28",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_28/Loans_2023_07.txt",
+          "company": "Компания 28",
+          "period": "2023-07",
+          "periodLabel": "Июль 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_29/OSV_2024_Q1.xlsx",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_29/PnL_2024_Q1.csv",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_29/Balance_20240331.xlsx",
+          "company": "Компания 29",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_29/Receivables_2024_Q1.xlsx",
+          "company": "Компания 29",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/OSV_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_30/PnL_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_30_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_30/Balance_20240630.xlsx",
+          "company": "Компания 30",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_30/Receivables_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_30/Inventory_2024_05.csv",
+          "company": "Компания 30",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Уточните источник данных — файл собран вручную",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_30/Legal_2024.csv",
+          "company": "Компания 30",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_30/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 30",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_31/OSV_2023_Q4.xlsx",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_31/PnL_2023_Q4.csv",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_31/Balance_20231231.xlsx",
+          "company": "Компания 31",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_31/Receivables_2023_Q4.xlsx",
+          "company": "Компания 31",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_32/OSV_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_32/PnL_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_32/Balance_20230930.xlsx",
+          "company": "Компания 32",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_32/Receivables_2023_Q3.xlsx",
+          "company": "Компания 32",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_32/Inventory_2023_08.csv",
+          "company": "Компания 32",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_32/Projects_2023.csv",
+          "company": "Компания 32",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_33/OSV_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_33/PnL_2024_Q1.csv",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_33/Balance_20240331.xlsx",
+          "company": "Компания 33",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_33/Receivables_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_33/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 33",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_34/OSV_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_34/PnL_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_34/Balance_20240630.xlsx",
+          "company": "Компания 34",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_34/Receivables_2024_Q2.xlsx",
+          "company": "Компания 34",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_34/Inventory_2024_05.csv",
+          "company": "Компания 34",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_35/OSV_2023_Q4.xlsx",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_35/PnL_2023_Q4.csv",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_35/Balance_20231231.xlsx",
+          "company": "Компания 35",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_35/Receivables_2023_Q4.xlsx",
+          "company": "Компания 35",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_35/Loans_2023_10.txt",
+          "company": "Компания 35",
+          "period": "2023-10",
+          "periodLabel": "Октябрь 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_35/Legal_2023.csv",
+          "company": "Компания 35",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_36/OSV_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_36/PnL_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_36/Balance_20230930.xlsx",
+          "company": "Компания 36",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_36/Receivables_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_36/Inventory_2023_08.csv",
+          "company": "Компания 36",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Дополните справочник подразделений для новых кодов",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_36/Projects_2023.csv",
+          "company": "Компания 36",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Уточните источник данных — файл собран вручную",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_36/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 36",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_37/OSV_2024_Q1.xlsx",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_37/PnL_2024_Q1.csv",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_37/Balance_20240331.xlsx",
+          "company": "Компания 37",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_37/Receivables_2024_Q1.xlsx",
+          "company": "Компания 37",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_38/OSV_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_38/PnL_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_38/Balance_20240630.xlsx",
+          "company": "Компания 38",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_38/Receivables_2024_Q2.xlsx",
+          "company": "Компания 38",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_38/Inventory_2024_05.csv",
+          "company": "Компания 38",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_39/OSV_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_39/PnL_2023_Q4.csv",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_39/Balance_20231231.xlsx",
+          "company": "Компания 39",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_39/Receivables_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_39/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 39",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_40/OSV_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_40/PnL_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_40/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_40_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_40/Balance_20230930.xlsx",
+          "company": "Компания 40",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_40/Receivables_2023_Q3.xlsx",
+          "company": "Компания 40",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_40/Inventory_2023_08.csv",
+          "company": "Компания 40",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Дополните справочник подразделений для новых кодов"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_40/Projects_2023.csv",
+          "company": "Компания 40",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_40/Legal_2023.csv",
+          "company": "Компания 40",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_41/OSV_2024_Q1.xlsx",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_41/PnL_2024_Q1.csv",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_41/Balance_20240331.xlsx",
+          "company": "Компания 41",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_41/Receivables_2024_Q1.xlsx",
+          "company": "Компания 41",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/OSV_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_42/PnL_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/Balance_20240630.xlsx",
+          "company": "Компания 42",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_42/Receivables_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_42/Inventory_2024_05.csv",
+          "company": "Компания 42",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_42/Loans_2024_04.txt",
+          "company": "Компания 42",
+          "period": "2024-04",
+          "periodLabel": "Апрель 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_42/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 42",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_43/OSV_2023_Q4.xlsx",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_43/PnL_2023_Q4.csv",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_43/Balance_20231231.xlsx",
+          "company": "Компания 43",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_43/Receivables_2023_Q4.xlsx",
+          "company": "Компания 43",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_44/OSV_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_44/PnL_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_44/Balance_20230930.xlsx",
+          "company": "Компания 44",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_44/Receivables_2023_Q3.xlsx",
+          "company": "Компания 44",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_44/Inventory_2023_08.csv",
+          "company": "Компания 44",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_44/Projects_2023.csv",
+          "company": "Компания 44",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_45/OSV_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_45/PnL_2024_Q1.csv",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_45/Balance_20240331.xlsx",
+          "company": "Компания 45",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_45/Receivables_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_45/Legal_2024.csv",
+          "company": "Компания 45",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_45/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 45",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_46/OSV_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_46/PnL_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_46/Balance_20240630.xlsx",
+          "company": "Компания 46",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_46/Receivables_2024_Q2.xlsx",
+          "company": "Компания 46",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_46/Inventory_2024_05.csv",
+          "company": "Компания 46",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_47/OSV_2023_Q4.xlsx",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_47/PnL_2023_Q4.csv",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_47/Balance_20231231.xlsx",
+          "company": "Компания 47",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_47/Receivables_2023_Q4.xlsx",
+          "company": "Компания 47",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/OSV_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_48/PnL_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/Balance_20230930.xlsx",
+          "company": "Компания 48",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_48/Receivables_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_48/Inventory_2023_08.csv",
+          "company": "Компания 48",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Уточните источник данных — файл собран вручную",
+            "Привяжите показатели к управленческой статье движения"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_48/Projects_2023.csv",
+          "company": "Компания 48",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Проверьте ИНН и названия — часть строк без идентификаторов",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_48/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 48",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_49/OSV_2024_Q1.xlsx",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_49/PnL_2024_Q1.csv",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_49/Balance_20240331.xlsx",
+          "company": "Компания 49",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_49/Receivables_2024_Q1.xlsx",
+          "company": "Компания 49",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_49/Loans_2024_01.txt",
+          "company": "Компания 49",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Уточните источник данных — файл собран вручную",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Дополните справочник подразделений для новых кодов"
+          ],
+          "attentionSummary": "Всего: 5 полей помечены системой"
+        },
+        {
+          "name": "Компания_50/OSV_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_50/PnL_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_50/PnL_2024_Q2_v2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_50_PnL_2024_Q2",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_50/Balance_20240630.xlsx",
+          "company": "Компания 50",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_50/Receivables_2024_Q2.xlsx",
+          "company": "Компания 50",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_50/Inventory_2024_05.csv",
+          "company": "Компания 50",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_50/Legal_2024.csv",
+          "company": "Компания 50",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_51/OSV_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_51/PnL_2023_Q4.csv",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_51/Balance_20231231.xlsx",
+          "company": "Компания 51",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_51/Receivables_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_51/Cashflow_2023_Q4.xlsx",
+          "company": "Компания 51",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_52/OSV_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_52/PnL_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_52/Balance_20230930.xlsx",
+          "company": "Компания 52",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_52/Receivables_2023_Q3.xlsx",
+          "company": "Компания 52",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_52/Inventory_2023_08.csv",
+          "company": "Компания 52",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Укажите валюту расчётов и курс пересчёта"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "Компания_52/Projects_2023.csv",
+          "company": "Компания 52",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_53/OSV_2024_Q1.xlsx",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_53/PnL_2024_Q1.csv",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_53/Balance_20240331.xlsx",
+          "company": "Компания 53",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_53/Receivables_2024_Q1.xlsx",
+          "company": "Компания 53",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/OSV_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_54/PnL_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/Balance_20240630.xlsx",
+          "company": "Компания 54",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_54/Receivables_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_54/Inventory_2024_05.csv",
+          "company": "Компания 54",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Задайте правило агрегации — в файле несколько листов с цифрами"
+          ],
+          "attentionSummary": "Всего: 4 блока данных стоит перепроверить"
+        },
+        {
+          "name": "Компания_54/Cashflow_2024_Q2.xlsx",
+          "company": "Компания 54",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_55/OSV_2023_Q4.xlsx",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_55/PnL_2023_Q4.csv",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_55/Balance_20231231.xlsx",
+          "company": "Компания 55",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_55/Receivables_2023_Q4.xlsx",
+          "company": "Компания 55",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_55/Legal_2023.csv",
+          "company": "Компания 55",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_56/OSV_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_56/PnL_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_56/Balance_20230930.xlsx",
+          "company": "Компания 56",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_56/Receivables_2023_Q3.xlsx",
+          "company": "Компания 56",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_56/Inventory_2023_08.csv",
+          "company": "Компания 56",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_56/Projects_2023.csv",
+          "company": "Компания 56",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Дополните справочник подразделений для новых кодов",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_56/Loans_2023_07.txt",
+          "company": "Компания 56",
+          "period": "2023-07",
+          "periodLabel": "Июль 2023",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "mapping",
+          "origin": "кредитный отдел",
+          "mappingHints": [
+            "Разметьте столбцы задолженности",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Поставьте соответствие между кодами проектов и центрами прибыли",
+            "Проверьте аналитики по складам и ячейкам хранения"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_57/OSV_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_57/PnL_2024_Q1.csv",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_57/Balance_20240331.xlsx",
+          "company": "Компания 57",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_57/Receivables_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_57/Cashflow_2024_Q1.xlsx",
+          "company": "Компания 57",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_58/OSV_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_58/PnL_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_58/Balance_20240630.xlsx",
+          "company": "Компания 58",
+          "period": "2024-06-30",
+          "periodLabel": "30.06.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_58/Receivables_2024_Q2.xlsx",
+          "company": "Компания 58",
+          "period": "2024-Q2",
+          "periodLabel": "II квартал 2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_58/Inventory_2024_05.csv",
+          "company": "Компания 58",
+          "period": "2024-05",
+          "periodLabel": "Май 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Сопоставьте новые статьи с планом счетов группы",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Проверьте ИНН и названия — часть строк без идентификаторов"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "Компания_59/OSV_2023_Q4.xlsx",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_59/PnL_2023_Q4.csv",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "ОФР",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "почта бухгалтера"
+        },
+        {
+          "name": "Компания_59/Balance_20231231.xlsx",
+          "company": "Компания 59",
+          "period": "2023-12-31",
+          "periodLabel": "31.12.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "папка клиента"
+        },
+        {
+          "name": "Компания_59/Receivables_2023_Q4.xlsx",
+          "company": "Компания 59",
+          "period": "2023-Q4",
+          "periodLabel": "IV квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/OSV_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_60/PnL_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/PnL_2023_Q3_v2.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Компания_60_PnL_2023_Q3",
+          "origin": "повторная выгрузка"
+        },
+        {
+          "name": "Компания_60/Balance_20230930.xlsx",
+          "company": "Компания 60",
+          "period": "2023-09-30",
+          "periodLabel": "30.09.2023",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив выгрузок"
+        },
+        {
+          "name": "Компания_60/Receivables_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        },
+        {
+          "name": "Компания_60/Inventory_2023_08.csv",
+          "company": "Компания 60",
+          "period": "2023-08",
+          "periodLabel": "Август 2023",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "склад",
+          "mappingHints": [
+            "Подтвердите коды складов и единицы измерения",
+            "Разделите управленческие и бухгалтерские суммы для корректной сверки",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Поставьте соответствие между кодами проектов и центрами прибыли"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "Компания_60/Projects_2023.csv",
+          "company": "Компания 60",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "origin": "проектный офис",
+          "mappingHints": [
+            "Определите тип отчёта для проектных данных",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "Компания_60/Legal_2023.csv",
+          "company": "Компания 60",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "юридический отдел"
+        },
+        {
+          "name": "Компания_60/Cashflow_2023_Q3.xlsx",
+          "company": "Компания 60",
+          "period": "2023-Q3",
+          "periodLabel": "III квартал 2023",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Система распределила 60 компаний по папкам и ИНН автоматически.",
+          "suggestion": "60 компаний в группе"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По шаблонам заголовков определены ОСВ, ОФР, Баланс, дебиторка, запасы и доп. данные.",
+          "suggestion": "Типы отчётов сопоставлены автоматически"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Дата и период распознаны по 2023–2024 годам, включая месяцы и кварталы.",
+          "suggestion": "Периоды: 2023–2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Компания_10_PnL_2024_Q2",
+          "files": [
+            "Компания_10/PnL_2024_Q2.xlsx",
+            "Компания_10/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 10 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 10, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 10 завершена. Строк объединено: 230."
+          }
+        },
+        {
+          "group": "Компания_20_PnL_2023_Q3",
+          "files": [
+            "Компания_20/PnL_2023_Q3.xlsx",
+            "Компания_20/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 20 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 20, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 20 завершена. Строк объединено: 240."
+          }
+        },
+        {
+          "group": "Компания_30_PnL_2024_Q2",
+          "files": [
+            "Компания_30/PnL_2024_Q2.xlsx",
+            "Компания_30/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 30 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 30, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 30 завершена. Строк объединено: 250."
+          }
+        },
+        {
+          "group": "Компания_40_PnL_2023_Q3",
+          "files": [
+            "Компания_40/PnL_2023_Q3.xlsx",
+            "Компания_40/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 40 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 40, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 40 завершена. Строк объединено: 260."
+          }
+        },
+        {
+          "group": "Компания_50_PnL_2024_Q2",
+          "files": [
+            "Компания_50/PnL_2024_Q2.xlsx",
+            "Компания_50/PnL_2024_Q2_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 50 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 50, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 50 завершена. Строк объединено: 270."
+          }
+        },
+        {
+          "group": "Компания_60_PnL_2023_Q3",
+          "files": [
+            "Компания_60/PnL_2023_Q3.xlsx",
+            "Компания_60/PnL_2023_Q3_v2.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Обновлённый отчёт Компания 60 сохранён, старая версия в архиве.",
+            "keepOld": "Сохраняем исходный P&L Компания 60, повторную выгрузку убрали.",
+            "merge": "Склейка версий Компания 60 завершена. Строк объединено: 280."
+          }
+        }
+      ]
+    },
+    {
+      "id": "zipArchive",
+      "label": "ZIP-архив группы",
+      "summary": {
+        "companies": 3,
+        "files": 28,
+        "periods": 5,
+        "formats": [
+          "zip"
+        ],
+        "description": "Архив с вложенными папками компаний"
+      },
+      "recognition": {
+        "recognized": 21,
+        "needsMapping": 4,
+        "duplicates": 3
+      },
+      "files": [
+        {
+          "name": "group_upload.zip/Company_A/OSV_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/PnL_2024_Q1.xlsx",
+          "company": "Компания А",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Balance_31_03.xlsx",
+          "company": "Компания А",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Inventory_feb.csv",
+          "company": "Компания А",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Нужно подтвердить единицы измерения",
+            "Привяжите показатели к управленческой статье движения",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Сопоставьте новые статьи с планом счетов группы"
+          ],
+          "attentionSummary": "Всего: 1 уточнение осталось подтвердить"
+        },
+        {
+          "name": "group_upload.zip/Company_A/Receivables.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/OSV_2024_Q1.xlsx",
+          "company": "Компания B",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Jan.xlsx",
+          "company": "Компания B",
+          "period": "2024-01",
+          "periodLabel": "Январь 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Feb.xlsx",
+          "company": "Компания B",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/PnL_Mar.xlsx",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "duplicate",
+          "duplicateGroup": "Company_B_PnL",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Balance_31_03.xlsx",
+          "company": "Компания B",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Inventory_march.csv",
+          "company": "Компания B",
+          "period": "2024-03",
+          "periodLabel": "Март 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/Receivables.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/OSV_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОСВ",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/PnL_Q1.xlsx",
+          "company": "Компания C",
+          "period": "2024-Q1",
+          "periodLabel": "I квартал 2024",
+          "type": "ОФР",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Balance_31_03.xlsx",
+          "company": "Компания C",
+          "period": "2024-03-31",
+          "periodLabel": "31.03.2024",
+          "type": "Баланс",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Inventory_feb.csv",
+          "company": "Компания C",
+          "period": "2024-02",
+          "periodLabel": "Февраль 2024",
+          "type": "Запасы",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Уточнить склад",
+            "Отметьте строки, которые относятся к закрытому периоду",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "group_upload.zip/Company_C/Receivables.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Дебиторка",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/security/events.csv",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Юр.события",
+          "format": "csv",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/security/partners.xlsx",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Контрагенты",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "служба безопасности"
+        },
+        {
+          "name": "group_upload.zip/Company_A/cashflow.xlsx",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/cashflow.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_C/cashflow.xlsx",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/readme.txt",
+          "company": "Группа",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "txt",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_A/projects.csv",
+          "company": "Компания А",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Задайте правило агрегации — в файле несколько листов с цифрами",
+            "Проверьте настройку НДС — встречены строки без ставки",
+            "Обозначьте межгрупповые операции, чтобы исключить их при консолидации"
+          ],
+          "attentionSummary": "Всего: 3 показателя требуют сверки"
+        },
+        {
+          "name": "group_upload.zip/Company_B/projects.csv",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Согласуйте датировку — выгрузка содержит смешанные периоды",
+            "Укажите валюту расчётов и курс пересчёта",
+            "Отметьте строки, которые относятся к закрытому периоду"
+          ],
+          "attentionSummary": "Всего: 2 параметра ждут проверки"
+        },
+        {
+          "name": "group_upload.zip/Company_C/projects.csv",
+          "company": "Компания C",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "csv",
+          "status": "mapping",
+          "mappingHints": [
+            "Укажите тип данных",
+            "Привяжите показатели к управленческой статье движения",
+            "Уточните источник данных — файл собран вручную",
+            "Проверьте настройку НДС — встречены строки без ставки"
+          ],
+          "attentionSummary": "Всего: 6 несоответствий найдены в выгрузке"
+        },
+        {
+          "name": "group_upload.zip/security/archive_2023.zip",
+          "company": "Группа",
+          "period": "2023",
+          "periodLabel": "2023",
+          "type": "Прочее",
+          "format": "zip",
+          "status": "recognized",
+          "origin": "архив"
+        },
+        {
+          "name": "group_upload.zip/Company_B/loans.xlsx",
+          "company": "Компания B",
+          "period": "2024",
+          "periodLabel": "2024",
+          "type": "Прочее",
+          "format": "xlsx",
+          "status": "recognized",
+          "origin": "финансовый отдел"
+        }
+      ],
+      "mappingSteps": [
+        {
+          "title": "Проверьте компанию/ИНН",
+          "description": "Архив содержит подпапки по компаниям.",
+          "suggestion": "Компания А • Компания B • Компания C"
+        },
+        {
+          "title": "Проверьте тип отчёта",
+          "description": "По структуре данных распознаны ОСВ и ОФР.",
+          "suggestion": "Баланс (на дату) и ОФР (за период)"
+        },
+        {
+          "title": "Проверьте период",
+          "description": "Выделен диапазон по именам файлов.",
+          "suggestion": "Январь–Март 2024"
+        }
+      ],
+      "duplicateResolutions": [
+        {
+          "group": "Company_B_PnL",
+          "files": [
+            "group_upload.zip/Company_B/PnL_Jan.xlsx",
+            "group_upload.zip/Company_B/PnL_Feb.xlsx",
+            "group_upload.zip/Company_B/PnL_Mar.xlsx"
+          ],
+          "messages": {
+            "keepNew": "Сохранён последний файл за март, предыдущие помечены как исторические.",
+            "keepOld": "Сохранили январскую версию, остальные спрятаны в архив.",
+            "merge": "Объединение трёх файлов завершено. Строк объединено: 312."
+          }
+        }
+      ]
+    }
+  ],
+  "consolidation": {
+    "baseSummary": {
+      "companies": 60,
+      "files": 331,
+      "period": "2023–2024, смешанные выгрузки",
+      "eliminatedPairs": 28
+    },
+    "totals": {
+      "before": {
+        "revenue": 684000000,
+        "cogs": 512000000,
+        "grossMargin": 172000000,
+        "interestPayable": 12800000,
+        "interestReceivable": 12800000,
+        "intraRevenue": 48000000,
+        "intraCogs": 48000000,
+        "note": "До исключения 60 компаний дают завышенные обороты и проценты"
+      },
+      "after": {
+        "revenue": 636000000,
+        "cogs": 464000000,
+        "grossMargin": 172000000,
+        "interestPayable": 0,
+        "interestReceivable": 0,
+        "note": "Исключения убрали 48 млн внутригрупповой выручки и проценты"
+      }
+    },
+    "eliminationEntries": [
+      {
+        "pair": "Компания 12 → Компания 27",
+        "description": "Поставка оборудования",
+        "amount": 18500000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания 08 ↔ Компания 19",
+        "description": "Совместные услуги",
+        "amount": 12800000,
+        "metric": "Выручка/Прочие расходы"
+      },
+      {
+        "pair": "Компания 33 → Компания 05",
+        "description": "Проценты по внутригрупповому займу",
+        "amount": 6400000,
+        "metric": "Проценты к получению/уплате"
+      },
+      {
+        "pair": "Компания 41 ↔ Компания 52",
+        "description": "Корректировка по остаткам",
+        "amount": 9200000,
+        "metric": "Консервативная корректировка по большей сумме"
+      },
+      {
+        "pair": "Компания 14 → Компания 44",
+        "description": "Передача сырья",
+        "amount": 8700000,
+        "metric": "Выручка/Себестоимость"
+      },
+      {
+        "pair": "Компания 60 ↔ Компания 11",
+        "description": "Перераспределение лицензий",
+        "amount": 6200000,
+        "metric": "Прочие доходы/расходы"
+      }
+    ],
+    "infoNotes": [
+      "Баланс — на дату. ОФР — за период. Аналогия: камера мгновенной и средней скорости.",
+      "Снятие внутригрупповых оборотов даёт честный результат группы."
+    ],
+    "ruleHints": [
+      "Исключаем проценты к уплате и к получению по внутригрупповым займам.",
+      "Консервативная корректировка: при расхождениях берём большую сумму.",
+      "Правило баланса: нет двойного учёта между дочерними компаниями."
+    ]
+  },
+  "detectors": {
+    "receivables": [
+      {
+        "counterparty": "Торговый дом \"Север\"",
+        "company": "Компания 03",
+        "days": 240,
+        "amount": 7200000,
+        "source": "Receivables_2024_Q1.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Метеор\"",
+        "company": "Компания 18",
+        "days": 305,
+        "amount": 9800000,
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "counterparty": "ЗАО \"Партнёр\"",
+        "company": "Компания 25",
+        "days": 188,
+        "amount": 6100000,
+        "source": "Receivables_2023_Q4.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Орион\"",
+        "company": "Компания 34",
+        "days": 330,
+        "amount": 11200000,
+        "source": "Receivables_2023_Q3.xlsx"
+      },
+      {
+        "counterparty": "ИП Сафронов",
+        "company": "Компания 42",
+        "days": 145,
+        "amount": 4500000,
+        "source": "Receivables_2024_Q1.xlsx"
+      },
+      {
+        "counterparty": "АО \"Логистика\"",
+        "company": "Компания 51",
+        "days": 276,
+        "amount": 8800000,
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "counterparty": "ООО \"Квант\"",
+        "company": "Компания 57",
+        "days": 365,
+        "amount": 12500000,
+        "source": "Receivables_2023_Q4.xlsx"
+      },
+      {
+        "counterparty": "ПАО \"Синтез\"",
+        "company": "Компания 60",
+        "days": 198,
+        "amount": 5400000,
+        "source": "Receivables_2023_Q3.xlsx"
+      }
+    ],
+    "inventory": [
+      {
+        "item": "Партия кабеля КБ-14",
+        "company": "Компания 18",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 2250000,
+        "source": "Inventory_2024_05.csv"
+      },
+      {
+        "item": "Компоненты серии X17",
+        "company": "Компания 12",
+        "issues": [
+          "истёк срок"
+        ],
+        "amount": 1840000,
+        "source": "Inventory_2024_02.csv"
+      },
+      {
+        "item": "Готовая продукция L2",
+        "company": "Компания 25",
+        "issues": [
+          "брак",
+          "долго лежит"
+        ],
+        "amount": 2760000,
+        "source": "Inventory_2023_11.csv"
+      },
+      {
+        "item": "Материалы проекта R",
+        "company": "Компания 33",
+        "issues": [
+          "долго лежит"
+        ],
+        "amount": 1610000,
+        "source": "Inventory_2023_08.csv"
+      },
+      {
+        "item": "Партия микросхем M9",
+        "company": "Компания 41",
+        "issues": [
+          "брак"
+        ],
+        "amount": 2380000,
+        "source": "Inventory_2024_02.csv"
+      },
+      {
+        "item": "Резервные модули S3",
+        "company": "Компания 54",
+        "issues": [
+          "долго лежит",
+          "истёк срок"
+        ],
+        "amount": 3120000,
+        "source": "Inventory_2023_11.csv"
+      }
+    ],
+    "legend": {
+      "receivables": "Дебиторка",
+      "inventory": "Запасы"
+    }
+  },
+  "liquidation": {
+    "before": {
+      "equity": 182000000,
+      "cash": 48500000,
+      "assets": [
+        {
+          "label": "Дебиторская задолженность",
+          "amount": 84500000
+        },
+        {
+          "label": "Запасы",
+          "amount": 67400000
+        },
+        {
+          "label": "Основные средства",
+          "amount": 123500000
+        },
+        {
+          "label": "Прочие активы",
+          "amount": 28500000
+        }
+      ]
+    },
+    "adjustments": [
+      {
+        "label": "Списание дебитора ООО \"Метеор\"",
+        "impact": -9800000,
+        "reason": ">300 дней без оплаты",
+        "source": "Receivables_2024_Q2.xlsx"
+      },
+      {
+        "label": "Списание партии КБ-14",
+        "impact": -2250000,
+        "reason": "неликвид > 10 месяцев",
+        "source": "Inventory_2024_05.csv"
+      },
+      {
+        "label": "Дисконт готовой продукции L2",
+        "impact": -1620000,
+        "reason": "брак и переоценка",
+        "source": "Inventory_2023_11.csv"
+      },
+      {
+        "label": "Резерв по проектам высокого риска",
+        "impact": -5400000,
+        "reason": "пересмотр денежных потоков",
+        "source": "Projects_2024.csv"
+      }
+    ],
+    "after": {
+      "equity": 132000000,
+      "cash": 62500000,
+      "ownerStatement": "Оценка: после очистки собственник может рассчитывать на ~62,5 млн руб. живыми деньгами."
+    }
+  },
+  "trafficLight": {
+    "statusLabels": {
+      "all": "Все",
+      "green": "Зелёные",
+      "yellow": "Жёлтые",
+      "red": "Красные"
+    },
+    "items": [
+      {
+        "name": "ООО \"Форвард\"",
+        "company": "Компания 03",
+        "status": "green",
+        "financial": "Платёж дисциплинирован, оборачиваемость 32 дня.",
+        "legal": "Нет активных судебных дел.",
+        "note": "Допустимый лимит 18 млн руб."
+      },
+      {
+        "name": "АО \"Логистика\"",
+        "company": "Компания 18",
+        "status": "yellow",
+        "financial": "Просрочка выросла до 60 дней.",
+        "legal": "Исполнительное производство на 4,2 млн руб.",
+        "note": "Рекомендация: ужесточить условия поставок."
+      },
+      {
+        "name": "ООО \"Метеор\"",
+        "company": "Компания 18",
+        "status": "red",
+        "financial": "Просрочка 305 дней, резкое падение оборотов.",
+        "legal": "Получено уведомление о подготовке к банкротству.",
+        "note": "Поставки остановлены, контроль службы безопасности."
+      },
+      {
+        "name": "ЗАО \"Партнёр\"",
+        "company": "Компания 25",
+        "status": "yellow",
+        "financial": "Просрочка 188 дней, есть частичные оплаты.",
+        "legal": "Претензионная работа без суда.",
+        "note": "Рекомендуем переход на предоплату."
+      },
+      {
+        "name": "ИП Сафронов",
+        "company": "Компания 42",
+        "status": "green",
+        "financial": "Оплата вовремя, обороты растут.",
+        "legal": "Нарушений нет.",
+        "note": "Можно расширить лимит до 7 млн руб."
+      },
+      {
+        "name": "ПАО \"Синтез\"",
+        "company": "Компания 60",
+        "status": "yellow",
+        "financial": "Промедление платежей до 50 дней.",
+        "legal": "Появилась судебная претензия контрагента.",
+        "note": "Контроль менеджмента, запрос финансовой отчётности."
+      },
+      {
+        "name": "ООО \"Квант\"",
+        "company": "Компания 57",
+        "status": "red",
+        "financial": "Просрочка 365 дней, высокая долговая нагрузка.",
+        "legal": "Инициирована процедура наблюдения.",
+        "note": "Договор расторгнут, требуется работа с обеспечением."
+      },
+      {
+        "name": "АО \"Регионстрой\"",
+        "company": "Компания 21",
+        "status": "green",
+        "financial": "Стабильные платежи, маржа 18%.",
+        "legal": "Нет негативных событий.",
+        "note": "Расширяем лимит до 22 млн руб."
+      }
+    ]
+  },
+  "finalSummary": {
+    "headline": "Минуты вместо дней. Минимум ручного труда. Комплекс отчётов готов.",
+    "points": [
+      "Файлы собраны, нормализованы и сведены в одну базу.",
+      "Проблемные зоны подсвечены автоматически.",
+      "Команда видит, где действовать первой."
+    ],
+    "disclaimer": "Демонстрационный прототип. Данные и расчёты упрощены."
+  }
+}
+};

--- a/config.json
+++ b/config.json
@@ -1,0 +1,24 @@
+{
+  "ctaUrl": "https://solward.example/test-drive",
+  "loading": {
+    "minSeconds": 25,
+    "maxSeconds": 35,
+    "stageLabels": [
+      "Импорт",
+      "Нормализация",
+      "Сшивка",
+      "Проверки",
+      "Готово"
+    ]
+  },
+  "receivables": {
+    "defaultThreshold": 180,
+    "minDays": 100,
+    "maxDays": 270
+  },
+  "inventoryMarkers": [
+    "долго лежит",
+    "истёк срок",
+    "брак"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Solward — интерактивный прототип</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <a class="visually-hidden" href="#main-content">Перейти к содержимому</a>
+    <div class="app">
+      <header>
+        <div class="header-top">
+          <div class="header-text">
+            <h1>Solward</h1>
+            <p>Интерактивный прототип: загрузка группы файлов, консолидация и ключевые аналитические экраны.</p>
+          </div>
+          <button
+            id="themeToggle"
+            class="button-ghost theme-toggle"
+            type="button"
+            aria-pressed="false"
+          >
+            <span class="theme-toggle__icon" aria-hidden="true"></span>
+            <span class="theme-toggle__label">Светлая тема</span>
+          </button>
+        </div>
+        <div class="summary-badges" role="status" aria-live="polite">
+          <span class="badge" id="badge-files">Файлов: 0</span>
+          <span class="badge" id="badge-companies">Компаний: 0</span>
+          <span class="badge" id="badge-periods">Периодов: 0</span>
+          <span class="badge" id="badge-formats">Форматы: —</span>
+        </div>
+      </header>
+      <main id="main-content">
+        <section id="upload-screen" class="screen active" aria-labelledby="upload-title">
+          <div class="section-title">
+            <div>
+              <h2 id="upload-title">Загрузка и нормализация данных</h2>
+              <p class="section-subtitle">
+                Поддерживается drag&drop папок и отдельных файлов. Система показывает, что распознано,
+                где требуется уточнение и какие есть дубликаты.
+              </p>
+            </div>
+            <button id="demoScenario" class="button-secondary" type="button">
+              Использовать демо-набор
+            </button>
+          </div>
+          <div class="drop-zone" id="dropZone" role="button" tabindex="0" aria-describedby="dropHint">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M12 3L7 8h3v4h4V8h3l-5-5z"
+                stroke="var(--accent)"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M5 15v2a2 2 0 002 2h10a2 2 0 002-2v-2"
+                stroke="var(--accent)"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <p id="dropHint">Перетащите файлы или папку сюда, либо выберите вручную.</p>
+            <div class="input-file button-primary">
+              <span>Выбрать файлы</span>
+              <input id="fileInput" type="file" multiple webkitdirectory aria-label="Выберите файлы" />
+            </div>
+            <small class="section-subtitle">
+              Поддерживаются форматы xlsx, csv, zip и смешанные наборы. Все расчёты выполняются локально.
+            </small>
+          </div>
+          <div class="upload-summary" aria-live="polite">
+            <article class="summary-card">
+              <strong id="summary-files">0</strong>
+              <span>Всего файлов</span>
+              <p id="summary-description" class="section-subtitle"></p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-companies">0</strong>
+              <span>Компаний</span>
+              <p id="recognition-legend" class="section-subtitle">
+                Распознано: 0 • Требует сверки: 0 • Дубликаты: 0
+              </p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-periods">0</strong>
+              <span>Периодов</span>
+              <p id="summary-periods-detail" class="section-subtitle">Периоды появятся после загрузки</p>
+            </article>
+            <article class="summary-card">
+              <strong id="summary-formats">—</strong>
+              <span>Форматы</span>
+              <p class="section-subtitle">xlsx • csv • zip</p>
+            </article>
+          </div>
+          <div class="upload-tabs">
+            <div class="tablist" role="tablist" aria-label="Разделы проверки">
+              <button
+                role="tab"
+                id="tab-attention"
+                aria-selected="true"
+                aria-controls="panel-attention"
+              >
+                Файлы, требующие внимания
+              </button>
+              <button
+                role="tab"
+                id="tab-duplicates"
+                aria-selected="false"
+                aria-controls="panel-duplicates"
+              >
+                Дубликаты
+              </button>
+              <button
+                role="tab"
+                id="tab-catalog"
+                aria-selected="false"
+                aria-controls="panel-catalog"
+              >
+                Каталог загрузки
+              </button>
+            </div>
+
+            <div
+              id="panel-attention"
+              class="upload-tabpanel"
+              role="tabpanel"
+              aria-labelledby="tab-attention"
+            >
+              <p class="section-subtitle">
+                Подтвердите подсказки системы, чтобы перейти к консолидации. Все предположения уже заполнены.
+              </p>
+              <p class="section-subtitle subtle-note">Мастер сверки доступен в панели действий ниже.</p>
+              <div class="file-list" id="attentionList" aria-live="polite"></div>
+            </div>
+
+            <div
+              id="panel-duplicates"
+              class="upload-tabpanel"
+              role="tabpanel"
+              aria-labelledby="tab-duplicates"
+              hidden
+            >
+              <p class="section-subtitle">
+                Выберите действие прямо на карточке компании: оставить старый файл, оставить новый или объединить данные.
+              </p>
+              <div class="file-list" id="duplicateList" aria-live="polite"></div>
+            </div>
+
+            <div
+              id="panel-catalog"
+              class="upload-tabpanel"
+              role="tabpanel"
+              aria-labelledby="tab-catalog"
+              hidden
+            >
+              <p class="section-subtitle">
+                Сгруппируйте загруженные файлы по компаниям или по периодам, чтобы увидеть полную картину.
+              </p>
+              <div class="tablist" role="tablist" aria-label="Группировка файлов">
+                <button role="tab" id="tab-companies" aria-selected="true" aria-controls="panel-companies">
+                  По компаниям
+                </button>
+                <button role="tab" id="tab-periods" aria-selected="false" aria-controls="panel-periods">
+                  По периодам
+                </button>
+              </div>
+              <div id="panel-companies" role="tabpanel" aria-labelledby="tab-companies">
+                <div class="file-list" id="companyFileList" aria-live="polite"></div>
+              </div>
+              <div id="panel-periods" role="tabpanel" aria-labelledby="tab-periods" hidden>
+                <div class="file-list" id="periodFileList" aria-live="polite"></div>
+              </div>
+            </div>
+          </div>
+          <div class="upload-actions" role="complementary" hidden>
+            <div class="upload-actions__info">
+              <h3 class="section-subtitle">Панель действий</h3>
+              <p class="section-subtitle">Переходите к сверке и запускайте консолидацию из одного места.</p>
+            </div>
+            <div class="upload-actions__buttons">
+              <button id="startMapping" type="button" class="button-secondary" disabled>
+                Открыть мастер сверки
+              </button>
+              <button id="startConsolidation" class="button-primary" type="button" disabled>
+                Начать консолидацию
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section id="progress-screen" class="screen" aria-labelledby="progress-title">
+          <div class="section-title">
+            <div>
+              <h2 id="progress-title">Консолидация запущена</h2>
+              <p class="section-subtitle">Имитация обработки занимает около 30 секунд.</p>
+            </div>
+          </div>
+          <div class="progress-container">
+            <div class="progress-bar" aria-hidden="true">
+              <span id="progressIndicator"></span>
+            </div>
+            <div id="progressValue" aria-live="polite">0%</div>
+            <div class="progress-steps" id="progressSteps" aria-hidden="true"></div>
+            <p class="section-subtitle" id="progressStatus">Подготовка</p>
+          </div>
+        </section>
+
+        <section id="triad-screen" class="screen" aria-labelledby="triad-title">
+          <div class="section-title">
+            <div>
+              <h2 id="triad-title">Комплекс отчётов готов</h2>
+              <p class="section-subtitle">Минуты вместо дней. Минимум ручного труда. Консолидация завершена.</p>
+            </div>
+          </div>
+          <nav class="triad-nav" aria-label="Навигация по экрану отчётов">
+            <button type="button" class="triad-nav-btn" data-target="consolidation" aria-pressed="true">
+              Консолидация
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="detectors" aria-pressed="false">
+              Сигнальные отчёты
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="liquidation" aria-pressed="false">
+              Ликвидационный баланс
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="traffic" aria-pressed="false">
+              Светофор
+            </button>
+            <button type="button" class="triad-nav-btn" data-target="final" aria-pressed="false">
+              Итог
+            </button>
+          </nav>
+          <div id="triad-panels">
+            <div id="panel-consolidation" class="triad-panel" role="region" aria-labelledby="triad-title">
+              <div class="metrics-grid" id="consolidationMetrics"></div>
+              <div class="elimination-controls">
+                <button
+                  id="toggleAdjustments"
+                  class="button-secondary"
+                  type="button"
+                  aria-pressed="true"
+                >
+                  Показать до исключений
+                </button>
+                <button
+                  id="showEliminations"
+                  class="button-secondary elimination-button"
+                  type="button"
+                  aria-expanded="false"
+                  aria-controls="eliminationDetails"
+                >
+                  Показать снятые внутригрупповые обороты
+                </button>
+              </div>
+              <div id="eliminationDetails" class="elimination-list" hidden></div>
+              <aside class="info-hints" id="consolidationHints"></aside>
+              <aside class="info-hints" id="consolidationRules"></aside>
+            </div>
+            <div id="panel-detectors" class="triad-panel" role="region" hidden>
+              <nav class="detector-tabs" aria-label="Вкладки сигнальных отчётов">
+                <button
+                  type="button"
+                  class="detector-tab-btn"
+                  data-detector="receivables"
+                  aria-controls="detector-receivables"
+                  aria-pressed="true"
+                >
+                  Просроченная задолженность
+                </button>
+                <button
+                  type="button"
+                  class="detector-tab-btn"
+                  data-detector="inventory"
+                  aria-controls="detector-inventory"
+                  aria-pressed="false"
+                >
+                  Запасы и неликвид
+                </button>
+              </nav>
+              <div class="detector-panels">
+                <section
+                  id="detector-receivables"
+                  class="detector-panel"
+                  aria-labelledby="receivable-title"
+                >
+                  <div>
+                    <h3 id="receivable-title">Просроченная задолженность</h3>
+                    <p class="section-subtitle">
+                      Управляйте порогом по дням. Всё, что выше порога, подсвечивается и может быть отправлено в светофор.
+                    </p>
+                  </div>
+                  <div class="range-control">
+                    <label for="thresholdRange">Порог дней</label>
+                    <input type="range" id="thresholdRange" min="100" max="270" value="180" />
+                    <span id="thresholdValue">180</span>
+                  </div>
+                  <div id="receivablesList"></div>
+                  <button id="sendToTraffic" class="button-secondary" type="button">
+                    Отправить в светофор
+                  </button>
+                  <p class="section-subtitle" id="trafficMessage" aria-live="polite"></p>
+                </section>
+                <section
+                  id="detector-inventory"
+                  class="detector-panel"
+                  aria-labelledby="inventory-title"
+                  hidden
+                >
+                  <div>
+                    <h3 id="inventory-title">Запасы и неликвид</h3>
+                    <p class="section-subtitle">
+                      Отметьте признаки, чтобы подсветить спорные позиции. Запасы и дебиторка — главные зоны внимания.
+                    </p>
+                  </div>
+                  <div id="inventoryFilters"></div>
+                  <div id="inventoryList"></div>
+                </section>
+              </div>
+            </div>
+            <div id="panel-liquidation" class="triad-panel" role="region" hidden>
+              <div class="section-title">
+                <div>
+                  <h3 class="section-subtitle">Очистка баланса от мусора</h3>
+                  <p class="section-subtitle">Показываем, сколько денег останется у собственника при продаже бизнеса.</p>
+                </div>
+                <button id="cleanBalance" class="button-primary" type="button">Очистить</button>
+              </div>
+              <div class="liquidation-layout">
+                <div class="liquidation-card">
+                  <h3>До очистки</h3>
+                  <p class="section-subtitle" id="liquidationBeforeSummary"></p>
+                  <ul id="liquidationAssets"></ul>
+                </div>
+                <div class="liquidation-card">
+                  <h3>Сценарные списания</h3>
+                  <ul id="liquidationAdjustments"></ul>
+                </div>
+                <div class="liquidation-card">
+                  <h3>После очистки</h3>
+                  <p class="section-subtitle" id="liquidationAfterSummary"></p>
+                  <p id="ownerStatement"></p>
+                </div>
+              </div>
+            </div>
+            <div id="panel-traffic" class="triad-panel" role="region" hidden>
+              <div class="traffic-controls">
+                <div role="group" aria-label="Фильтр статуса" id="trafficFilters"></div>
+                <label for="trafficCompany">Компания</label>
+                <select id="trafficCompany" aria-label="Фильтр по компании">
+                  <option value="all">Все компании</option>
+                </select>
+              </div>
+              <div class="traffic-list" id="trafficList"></div>
+            </div>
+            <div id="panel-final" class="triad-panel final-screen" role="region" hidden>
+              <h3 id="finalHeadline"></h3>
+              <ul id="finalPoints"></ul>
+              <p class="disclaimer" id="finalDisclaimer"></p>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+    <a id="ctaButton" class="cta-floating" href="#" target="_blank" rel="noopener">Записаться на тест-драйв</a>
+    <template id="duplicateBulkTemplate">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="duplicateBulkTitle">
+        <h3 id="duplicateBulkTitle">Как обработать дубликаты?</h3>
+        <p>Выберите массовое действие для обнаруженных дубликатов. Решение можно изменить позже.</p>
+        <div class="modal-options" data-role="options"></div>
+        <div class="modal-actions">
+          <button type="button" class="button-secondary" data-role="close">Закрыть</button>
+        </div>
+      </div>
+    </template>
+    <template id="mappingStepTemplate">
+      <div class="modal" role="dialog" aria-modal="true" aria-live="polite">
+        <h3>Сверка и подготовка данных к консолидации</h3>
+        <div data-role="list" class="modal-list"></div>
+        <div class="modal-actions">
+          <button type="button" class="button-secondary" data-role="cancel">Закрыть</button>
+          <button type="button" class="button-primary" data-role="confirm">Подтвердить подготовку</button>
+        </div>
+      </div>
+    </template>
+    <script src="assets/js/offlineData.js" defer></script>
+    <script src="assets/js/app.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -176,20 +176,16 @@
               </div>
             </div>
           </div>
-          <div class="upload-actions" role="complementary" hidden>
-            <div class="upload-actions__info">
-              <h3 class="section-subtitle">Панель действий</h3>
-              <p class="section-subtitle">Переходите к сверке и запускайте консолидацию из одного места.</p>
-            </div>
-            <div class="upload-actions__buttons">
-              <button id="startMapping" type="button" class="button-secondary" disabled>
-                Открыть мастер сверки
-              </button>
-              <button id="startConsolidation" class="button-primary" type="button" disabled>
-                Начать консолидацию
-              </button>
-            </div>
-          </div>
+          <button
+            id="workflowFab"
+            class="workflow-fab"
+            type="button"
+            hidden
+            disabled
+            aria-disabled="true"
+          >
+            Открыть мастер сверки
+          </button>
         </section>
 
         <section id="progress-screen" class="screen" aria-labelledby="progress-title">
@@ -364,7 +360,6 @@
         </section>
       </main>
     </div>
-    <a id="ctaButton" class="cta-floating" href="#" target="_blank" rel="noopener">Записаться на тест-драйв</a>
     <template id="duplicateBulkTemplate">
       <div class="modal" role="dialog" aria-modal="true" aria-labelledby="duplicateBulkTitle">
         <h3 id="duplicateBulkTitle">Как обработать дубликаты?</h3>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             <span class="theme-toggle__label">Светлая тема</span>
           </button>
         </div>
-        <div class="summary-badges" role="status" aria-live="polite">
+        <div class="summary-badges" role="status" aria-live="polite" hidden>
           <span class="badge" id="badge-files">Файлов: 0</span>
           <span class="badge" id="badge-companies">Компаний: 0</span>
           <span class="badge" id="badge-periods">Периодов: 0</span>
@@ -68,11 +68,11 @@
               <span>Выбрать файлы</span>
               <input id="fileInput" type="file" multiple webkitdirectory aria-label="Выберите файлы" />
             </div>
-            <small class="section-subtitle">
+            <small id="dropInfoNote" class="section-subtitle" hidden>
               Поддерживаются форматы xlsx, csv, zip и смешанные наборы. Все расчёты выполняются локально.
             </small>
           </div>
-          <div class="upload-summary" aria-live="polite">
+          <div class="upload-summary" aria-live="polite" hidden>
             <article class="summary-card">
               <strong id="summary-files">0</strong>
               <span>Всего файлов</span>

--- a/index.html
+++ b/index.html
@@ -225,9 +225,6 @@
             <button type="button" class="triad-nav-btn" data-target="traffic" aria-pressed="false">
               Светофор
             </button>
-            <button type="button" class="triad-nav-btn" data-target="final" aria-pressed="false">
-              Итог
-            </button>
           </nav>
           <div id="triad-panels">
             <div id="panel-consolidation" class="triad-panel" role="region" aria-labelledby="triad-title">
@@ -253,7 +250,6 @@
               </div>
               <div id="eliminationDetails" class="elimination-list" hidden></div>
               <aside class="info-hints" id="consolidationHints"></aside>
-              <aside class="info-hints" id="consolidationRules"></aside>
             </div>
             <div id="panel-detectors" class="triad-panel" role="region" hidden>
               <nav class="detector-tabs" aria-label="Вкладки сигнальных отчётов">
@@ -350,11 +346,6 @@
                 </select>
               </div>
               <div class="traffic-list" id="trafficList"></div>
-            </div>
-            <div id="panel-final" class="triad-panel final-screen" role="region" hidden>
-              <h3 id="finalHeadline"></h3>
-              <ul id="finalPoints"></ul>
-              <p class="disclaimer" id="finalDisclaimer"></p>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add tab navigation inside the "Сигнальные отчёты" screen to switch between receivables and inventory views
- style the new detector tabs to span the full panel width and highlight the active section
- update application state and handlers so the selected detector tab persists while scenarios render

## Testing
- python -m json.tool config.json >/dev/null
- python -m json.tool assets/data/mockData.json >/dev/null

------
https://chatgpt.com/codex/tasks/task_e_68d399221cec83298c41a0d7c800564e